### PR TITLE
Fix release workflow Python version mismatch

### DIFF
--- a/.github/workflows/semantic_release.yml
+++ b/.github/workflows/semantic_release.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.8"
+          python-version: "3.10"
 
       - name: Install pipenv and project dependencies
         run: |


### PR DESCRIPTION
## What this PR does

This PR fixes the release workflow failure by aligning the workflow Python version with the project's Pipenv requirement.

Changes in this PR:
- changes the release workflow from Python 3.8 to Python 3.10

## Why this is needed

The updated semantic release action is no longer the failing part.

The workflow now fails during `pipenv install --dev` because the repository expects Python 3.10, while the release workflow installs Python 3.8.

From the failed run:

- `actions/setup-python` installed Python 3.8
- `pipenv install --dev` then failed with `Python 3.10 was not found on your system`

## Expected result

After this PR:
- `pipenv install --dev` should succeed in the release workflow
- semantic release should be able to continue to the versioning and publish steps