### PR TITLE
fix(ci): create GitHub release explicitly and skip existing PyPI uploads

### DIFF
--- a/.github/workflows/semantic_release.yml
+++ b/.github/workflows/semantic_release.yml
@@ -37,20 +37,44 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
       - name: Create version commit and tag
+        id: semrel
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: semantic-release version
+        run: |
+          BEFORE_TAG="$(git describe --tags --abbrev=0 2>/dev/null || true)"
+          semantic-release version
+          AFTER_TAG="$(git describe --tags --abbrev=0 2>/dev/null || true)"
 
-      - name: Publish GitHub release
+          if [ "$BEFORE_TAG" != "$AFTER_TAG" ] && [ -n "$AFTER_TAG" ]; then
+            echo "released=true" >> "$GITHUB_OUTPUT"
+            echo "version=${AFTER_TAG#v}" >> "$GITHUB_OUTPUT"
+            echo "tag=$AFTER_TAG" >> "$GITHUB_OUTPUT"
+          else
+            echo "released=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Push release commit and tag
+        if: steps.semrel.outputs.released == 'true'
+        run: |
+          git push origin HEAD:master --follow-tags
+
+      - name: Create GitHub release
+        if: steps.semrel.outputs.released == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: semantic-release publish
+        run: |
+          gh release create "${{ steps.semrel.outputs.tag }}" \
+            --generate-notes \
+            --title "${{ steps.semrel.outputs.tag }}"
 
       - name: Build Python distributions
+        if: steps.semrel.outputs.released == 'true'
         run: python -m build
 
       - name: Publish package distributions to PyPI
+        if: steps.semrel.outputs.released == 'true'
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: __token__
           password: ${{ secrets.PYPI_TOKEN }}
+          skip-existing: true


### PR DESCRIPTION
## Summary

Fix the semantic release workflow so it:

- creates and pushes the semantic-release version bump commit and tag
- creates the GitHub Release explicitly with `gh release create`
- only builds and publishes when a new release was actually created
- avoids failing on reruns when the same files already exist on PyPI

## Problem

The previous workflow could bump the version locally to `0.5.6`, but still not create a GitHub Release.
After that, the workflow continued to build and upload distributions, which caused PyPI to fail with `400 File already exists` on reruns.

## Changes

- keep using `python-semantic-release==7.34.6`
- detect whether `semantic-release version` actually created a new tag
- push the release commit and tag back to `master`
- create the GitHub Release explicitly via GitHub CLI
- guard build/publish steps so they run only when a new release was created
- set `skip-existing: true` for PyPI publishing

## Expected result

After merging to `master`, the workflow should:

1. calculate the next semantic version
2. create the version bump commit and git tag
3. push them to GitHub
4. create a GitHub Release for that tag
5. build and upload the package to PyPI
6. avoid failing on reruns if the same PyPI files already exist