### PR TITLE
fix(ci): configure semantic-release to update changelog

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -3,3 +3,4 @@ python-tag = py38
 
 [semantic_release]
 version_variable = setup.py:__version__
+changelog_file = CHANGELOG.md


### PR DESCRIPTION
## Summary
Configure python-semantic-release to write release notes to CHANGELOG.md.

## Changes
- add `changelog_file = CHANGELOG.md` to `[semantic_release]` in `setup.cfg`
- ensure `CHANGELOG.md` exists

## Why
Releases are being created, but the changelog file is not updated because semantic-release is not told to write to it.