### PR TITLE
fix(ci): generate changelog explicitly in release workflow

### DIFF
--- a/.github/workflows/semantic_release.yml
+++ b/.github/workflows/semantic_release.yml
@@ -42,10 +42,19 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           BEFORE_TAG="$(git describe --tags --abbrev=0 2>/dev/null || true)"
+
           semantic-release version
+
           AFTER_TAG="$(git describe --tags --abbrev=0 2>/dev/null || true)"
 
           if [ "$BEFORE_TAG" != "$AFTER_TAG" ] && [ -n "$AFTER_TAG" ]; then
+            semantic-release changelog
+
+            if ! git diff --quiet -- CHANGELOG.md; then
+              git add CHANGELOG.md
+              git commit --amend --no-edit
+            fi
+
             echo "released=true" >> "$GITHUB_OUTPUT"
             echo "version=${AFTER_TAG#v}" >> "$GITHUB_OUTPUT"
             echo "tag=$AFTER_TAG" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary
Generate CHANGELOG.md explicitly during the release workflow.

## Changes
- run `semantic-release changelog` after `semantic-release version`
- amend the release commit if CHANGELOG.md changed
- keep the existing explicit GitHub release creation and PyPI publish flow

## Why
The current workflow successfully creates the version bump commit, tag, GitHub release, and PyPI publish, but CHANGELOG.md is still not updated in the repository. This makes changelog generation explicit instead of relying on implicit behavior from the older python-semantic-release setup.