### PR TITLE
fix(ci): write semantic-release changelog to file

### DIFF
--- a/.github/workflows/semantic_release.yml
+++ b/.github/workflows/semantic_release.yml
@@ -48,7 +48,7 @@ jobs:
           AFTER_TAG="$(git describe --tags --abbrev=0 2>/dev/null || true)"
 
           if [ "$BEFORE_TAG" != "$AFTER_TAG" ] && [ -n "$AFTER_TAG" ]; then
-            semantic-release changelog
+            semantic-release changelog > CHANGELOG.md
 
             if ! git diff --quiet -- CHANGELOG.md; then
               git add CHANGELOG.md


### PR DESCRIPTION
## Summary
Fix semantic release workflow so CHANGELOG.md is actually written and included in the amended release commit.

## Changes
- redirect `semantic-release changelog` output to `CHANGELOG.md`
- keep amending the release commit when CHANGELOG.md changes
- leave the rest of the release flow unchanged

## Testing
- not run locally
- workflow logic reviewed against current failing behavior