### PR TITLE
fix(ci): remove unrelated test job from release workflow

### DIFF
--- a/.github/workflows/semantic_release.yml
+++ b/.github/workflows/semantic_release.yml
@@ -9,34 +9,9 @@ permissions:
   contents: write
 
 jobs:
-  test:
-    name: Test
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: ["3.10"]
-
-    steps:
-      - name: Check out repository
-        uses: actions/checkout@v4
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.python-version }}
-
-      - name: Install pipenv and project dependencies
-        run: |
-          python -m pip install --upgrade pip pipenv
-          pipenv sync --dev
-
-      - name: Run tests
-        run: pipenv run pytest
-
   release:
     name: Release to GitHub and PyPI
     runs-on: ubuntu-latest
-    needs: test
 
     steps:
       - name: Check out repository


### PR DESCRIPTION
## Summary
Remove the unrelated test job from the semantic release workflow.

## Why
The task was only to fix changelog persistence and GitHub release creation. Adding a separate test job was unnecessary and introduced unrelated failures.

## Changes
- remove the `test` job entirely
- keep the changelog amend flow
- keep GitHub release creation
- keep PyPI publish using the existing API token flow