### PR TITLE
chore(ci): add concurrency guard to release workflow

### DIFF
--- a/.github/workflows/semantic_release.yml
+++ b/.github/workflows/semantic_release.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - master
 
+concurrency:
+  group: release-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 permissions:
   contents: write
 
@@ -41,14 +45,11 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           BEFORE_TAG="$(git describe --tags --abbrev=0 2>/dev/null || true)"
-
           semantic-release version
-
           AFTER_TAG="$(git describe --tags --abbrev=0 2>/dev/null || true)"
 
           if [ "$BEFORE_TAG" != "$AFTER_TAG" ] && [ -n "$AFTER_TAG" ]; then
             semantic-release changelog
-
             if ! git diff --quiet -- CHANGELOG.md; then
               git add CHANGELOG.md
               git commit --amend --no-edit
@@ -56,7 +57,6 @@ jobs:
             fi
 
             git push origin HEAD:master --follow-tags --force
-
             echo "released=true" >> "$GITHUB_OUTPUT"
             echo "version=${AFTER_TAG#v}" >> "$GITHUB_OUTPUT"
             echo "tag=$AFTER_TAG" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## What this PR does

This PR hardens the existing Python release workflow by adding a concurrency guard.

## Change made

- adds a top-level `concurrency` block to `.github/workflows/semantic_release.yml`

## Why this is needed

Release runs on `master` should not overlap. If multiple release workflows run at the same time, they can interfere with tagging, changelog updates, and pushes.

This change makes release execution serialized while keeping the current release behavior otherwise unchanged.

## Scope

This PR intentionally changes only the release workflow concurrency setting.

It does not change:
- CI workflow
- Docker workflows
- packaging
- semantic-release configuration
- PyPI publishing method
- tests

## Expected result

- only one release run per ref executes at a time
- in-progress release runs are not canceled
- the current Python release flow continues to work as before