### PR TITLE
feat(ci): add Docker publish workflow triggered by release

### DIFF
--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -1,0 +1,69 @@
+name: Docker Publish
+
+on:
+  workflow_run:
+    workflows:
+      - Semantic Release
+    types:
+      - completed
+
+concurrency:
+  group: docker-publish-${{ github.event.workflow_run.head_branch }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  docker-publish:
+    name: Build and publish Docker image
+    if: >
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.head_branch == 'master'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out released commit
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+
+      - name: Determine image tags
+        shell: bash
+        run: |
+          VERSION=$(python - <<'PY'
+          import re
+          from pathlib import Path
+
+          content = Path("setup.py").read_text()
+          match = re.search(r'^__version__\s*=\s*"([^"]+)"', content, re.MULTILINE)
+          if not match:
+              raise SystemExit("Could not find __version__ in setup.py")
+          print(match.group(1))
+          PY
+          )
+
+          MAJOR_MINOR=$(echo "$VERSION" | cut -d. -f1,2)
+
+          echo "VERSION=$VERSION" >> "$GITHUB_ENV"
+          echo "MAJOR_MINOR=$MAJOR_MINOR" >> "$GITHUB_ENV"
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push multi-arch image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          platforms: linux/amd64,linux/arm64,linux/arm/v7,linux/arm/v6
+          tags: |
+            tvallas/mtr2mqtt:${{ env.VERSION }}
+            tvallas/mtr2mqtt:${{ env.MAJOR_MINOR }}
+            tvallas/mtr2mqtt:latest


### PR DESCRIPTION
## What this PR does

This PR adds a dedicated Docker publish workflow that runs only after a successful Python release workflow.

## Change made

- adds `.github/workflows/docker_publish.yml`
- triggers Docker publishing from successful completion of the existing `Semantic Release` workflow
- checks out the exact released commit
- builds and pushes the Docker image to Docker Hub
- publishes tags for:
  - exact version
  - major.minor
  - latest

## Why this is needed

The repository already has a Python-only release workflow and the Dockerfile already builds from source, so Docker publishing should be handled as a separate post-release workflow.

This keeps Docker publishing decoupled from the Python release process and avoids tying Docker image publication to PyPI timing.

## Scope

This PR intentionally does only one thing:
- add a dedicated Docker publish workflow

It does not change:
- application code
- CI workflow
- Python release workflow
- Dockerfile
- packaging
- security scanning
- old workflow cleanup

## Expected result

After a successful run of `Semantic Release` on `master`, GitHub Actions should automatically publish the Docker image to Docker Hub as:
- `tvallas/mtr2mqtt:X.Y.Z`
- `tvallas/mtr2mqtt:X.Y`
- `tvallas/mtr2mqtt:latest`