### PR TITLE
chore(ci): simplify Docker workflow to PR smoke build

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,64 +1,33 @@
-name: docker-build-push
+name: Docker
 
 on:
   pull_request:
     branches:
-      - 'master'
+      - master
+
+concurrency:
+  group: docker-smoke-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
 
 jobs:
-  debug:
-    name: Debug
+  build:
+    name: build
     runs-on: ubuntu-latest
+
     steps:
-      - name: Dump env
-        run: env | sort
-      - name: Dump GitHub context
-        env:
-          GITHUB_CONTEXT: ${{ toJson(github) }}
-        run: echo "$GITHUB_CONTEXT"
-  docker:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Set up Python 3.10
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.10"
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install pipenv
-          make install
-      - name: Get current version
-        run: echo "mtr2mqtt_version=$(pipenv run semantic-release print-version --current)" >> $GITHUB_ENV
-      - name: Docker meta
-        id: meta
-        uses: crazy-max/ghaction-docker-meta@v2
-        with:
-          images: tvallas/mtr2mqtt
-          tags: |
-            type=ref,event=branch
-            type=ref,event=pr
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
-      - name: Login to DockerHub
-        if: github.event_name != 'pull_request'
-        uses: docker/login-action@v1
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Build and push
-        uses: docker/build-push-action@v2
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build Docker image
+        uses: docker/build-push-action@v6
         with:
           context: .
-          platforms: linux/amd64,linux/arm64,linux/arm/v7,linux/arm/v6
-          push: ${{ github.event_name != 'pull_request' }}
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          build-args: |
-            VERSION=${{ env.mtr2mqtt_version }}
+          push: false
+          load: false
+          tags: mtr2mqtt:pr-smoke


### PR DESCRIPTION
## What this PR does

This PR cleans up the legacy `docker.yml` workflow and keeps it only as a lightweight pull request Docker smoke-build workflow.

## Changes made

- removes the obsolete debug job
- keeps `docker.yml` as a PR-only workflow targeting `master`
- updates it to perform only a Docker smoke build
- removes publish-oriented behavior from this workflow

## Why this is needed

The repository already has a dedicated `docker_publish.yml` workflow for real Docker image publishing after a successful release.

The old `docker.yml` should no longer act like a publish pipeline or contain debugging-only jobs. Its remaining useful purpose is to provide a lightweight Docker build check for pull requests.

## Scope

This PR changes only:
- `.github/workflows/docker.yml`

This PR does not change:
- `docker_publish.yml`
- `semantic_release.yml`
- `ci.yml`
- `Dockerfile`
- application code

## Expected result

After this PR:
- pull requests to `master` will still get a Docker smoke-build check
- the obsolete debug job is gone
- Docker image publishing remains handled only by `docker_publish.yml`