### PR TITLE
test: expand unit coverage for parser and helpers

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5,15 +5,6 @@ import pytest
 from context import mtr2mqtt
 from mtr2mqtt import cli
 
-MTR2MQTT_ARGS = "--mqtt localhost"
-
-# def test_parser_without_mqtt_server():
-#     """
-#     Without a specified mqtt server the parser will exit.
-#     """
-#     with pytest.raises(SystemExit):
-#         parser = cli.create_parser()
-#         parser.parse_args([])
 
 def test_parser_with_mqtt_server_option_without_value():
     """
@@ -23,6 +14,7 @@ def test_parser_with_mqtt_server_option_without_value():
         parser = cli.create_parser()
         parser.parse_args(["--mqtt-host"])
 
+
 def test_parser_with_mqtt_server():
     """
     The parser will not exit if it receives mqtt option and value
@@ -30,4 +22,127 @@ def test_parser_with_mqtt_server():
     parser = cli.create_parser()
     args = parser.parse_args(["--mqtt-host", "localhost"])
 
-    assert args.mqtt_host == 'localhost'
+    assert args.mqtt_host == "localhost"
+
+
+def test_parser_defaults_without_arguments(monkeypatch):
+    """
+    Parser uses the built-in defaults when environment variables are not set.
+    """
+    monkeypatch.delenv("MTR2MQTT_SERIAL_PORT", raising=False)
+    monkeypatch.delenv("MTR2MQTT_BAUDRATE", raising=False)
+    monkeypatch.delenv("MTR2MQTT_SERIAL_TIMEOUT", raising=False)
+    monkeypatch.delenv("MTR2MQTT_SCL_ADDRESS", raising=False)
+    monkeypatch.delenv("MTR2MQTT_MQTT_HOST", raising=False)
+    monkeypatch.delenv("MTR2MQTT_MQTT_PORT", raising=False)
+    monkeypatch.delenv("MTR2MQTT_METADATA_FILE", raising=False)
+    monkeypatch.delenv("MTR2MQTT_DEBUG", raising=False)
+    monkeypatch.delenv("MTR2MQTT_QUIET", raising=False)
+
+    parser = cli.create_parser()
+    args = parser.parse_args([])
+
+    assert args.serial_port is None
+    assert args.baudrate == 9600
+    assert args.serial_timeout == 1
+    assert args.scl_address == 126
+    assert args.mqtt_host is None
+    assert args.mqtt_port == 1883
+    assert args.metadata_file is None
+    assert args.debug is False
+    assert args.quiet is False
+    assert args.version is False
+
+
+def test_parser_reads_environment_defaults(monkeypatch):
+    """
+    Parser uses supported environment variables as defaults.
+    """
+    monkeypatch.setenv("MTR2MQTT_SERIAL_PORT", "/dev/ttyUSB0")
+    monkeypatch.setenv("MTR2MQTT_BAUDRATE", "115200")
+    monkeypatch.setenv("MTR2MQTT_SERIAL_TIMEOUT", "5")
+    monkeypatch.setenv("MTR2MQTT_SCL_ADDRESS", "1")
+    monkeypatch.setenv("MTR2MQTT_MQTT_HOST", "mqtt.example")
+    monkeypatch.setenv("MTR2MQTT_MQTT_PORT", "1884")
+    monkeypatch.setenv("MTR2MQTT_METADATA_FILE", "tests/metadata.yml")
+    monkeypatch.setenv("MTR2MQTT_DEBUG", "true")
+    monkeypatch.delenv("MTR2MQTT_QUIET", raising=False)
+
+    parser = cli.create_parser()
+    args = parser.parse_args([])
+
+    assert args.serial_port == "/dev/ttyUSB0"
+    assert args.baudrate == 115200
+    assert args.serial_timeout == 5
+    assert args.scl_address == 1
+    assert args.mqtt_host == "mqtt.example"
+    assert args.mqtt_port == 1884
+    assert args.metadata_file == "tests/metadata.yml"
+    assert args.debug is True
+    assert args.quiet is False
+
+
+def test_parser_debug_flag_enables_debug():
+    """
+    The debug flag is parsed as a boolean store_true option.
+    """
+    parser = cli.create_parser()
+    args = parser.parse_args(["--debug"])
+
+    assert args.debug is True
+    assert args.quiet is False
+    assert args.version is False
+
+
+def test_parser_quiet_flag_enables_quiet():
+    """
+    The quiet flag is parsed as a boolean store_true option.
+    """
+    parser = cli.create_parser()
+    args = parser.parse_args(["--quiet"])
+
+    assert args.quiet is True
+    assert args.debug is False
+    assert args.version is False
+
+
+def test_parser_rejects_debug_and_quiet_together():
+    """
+    Mutually exclusive debug and quiet flags cannot be used together.
+    """
+    parser = cli.create_parser()
+
+    with pytest.raises(SystemExit):
+        parser.parse_args(["--debug", "--quiet"])
+
+
+def test_parser_parses_common_options():
+    """
+    The parser accepts common numeric and file options.
+    """
+    parser = cli.create_parser()
+    args = parser.parse_args([
+        "--mqtt-host", "localhost",
+        "--mqtt-port", "1885",
+        "--baudrate", "115200",
+        "--serial-timeout", "2",
+        "--scl-address", "0",
+        "--metadata-file", "tests/metadata.yml",
+    ])
+
+    assert args.mqtt_host == "localhost"
+    assert args.mqtt_port == "1885"
+    assert args.baudrate == 115200
+    assert args.serial_timeout == "2"
+    assert args.scl_address == 0
+    assert args.metadata_file == "tests/metadata.yml"
+
+
+def test_parser_rejects_invalid_scl_address():
+    """
+    The parser rejects unsupported SCL addresses.
+    """
+    parser = cli.create_parser()
+
+    with pytest.raises(SystemExit):
+        parser.parse_args(["--scl-address", "124"])

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -2,6 +2,8 @@
 Tests for metadata module
 """
 import json
+from pathlib import Path
+
 from context import mtr2mqtt
 from mtr2mqtt import metadata
 
@@ -10,19 +12,21 @@ METADATA_TEST_FILE = "tests/metadata.yml"
 METADATA_TEST_FILE_OUTPUT = json.dumps(
     [
         {
-            'id': 1234,
-            'location': 'Room',
-            'unit': 'C'
+            "id": 1234,
+            "location": "Room",
+            "unit": "C"
         },
         {
-            'id': 2345,
-            'location': 'Room 2',
-            'unit': '%'
+            "id": 2345,
+            "location": "Room 2",
+            "unit": "%"
         }
-    ])
+    ]
+)
 METADATA_TRANSMITTER_ID = 2345
 
-METADATA_TEST_TRANSMITTER_OUTPUT = {'location': 'Room 2', 'unit': '%'}
+METADATA_TEST_TRANSMITTER_OUTPUT = {"location": "Room 2", "unit": "%"}
+
 
 def test_metadata_file_load():
     """
@@ -30,10 +34,59 @@ def test_metadata_file_load():
     """
     assert metadata.loadfile(METADATA_TEST_FILE) == METADATA_TEST_FILE_OUTPUT
 
+
 def test_metadata_get_data():
     """
     metadata.get_data returns transmitter metadata
     """
     assert metadata.get_data(
         METADATA_TRANSMITTER_ID,
-        METADATA_TEST_FILE_OUTPUT) ==  METADATA_TEST_TRANSMITTER_OUTPUT
+        METADATA_TEST_FILE_OUTPUT
+    ) == METADATA_TEST_TRANSMITTER_OUTPUT
+
+
+def test_metadata_get_data_returns_none_for_missing_transmitter():
+    """
+    metadata.get_data returns None when transmitter id is not present.
+    """
+    assert metadata.get_data(9999, METADATA_TEST_FILE_OUTPUT) is None
+
+
+def test_metadata_get_data_with_empty_metadata_list():
+    """
+    metadata.get_data returns None when metadata input is an empty list.
+    """
+    assert metadata.get_data(2345, json.dumps([])) is None
+
+
+def test_metadata_loadfile_with_empty_file(tmp_path):
+    """
+    metadata.loadfile returns JSON null for an empty YAML file.
+    """
+    metadata_file = tmp_path / "empty_metadata.yml"
+    metadata_file.write_text("", encoding="utf-8")
+
+    assert metadata.loadfile(str(metadata_file)) == "null"
+
+
+def test_metadata_loadfile_with_unexpected_mapping_content(tmp_path):
+    """
+    metadata.loadfile preserves unexpected but valid YAML content as JSON.
+    """
+    metadata_file = tmp_path / "mapping_metadata.yml"
+    metadata_file.write_text("id: 1234\nlocation: Room\n", encoding="utf-8")
+
+    assert metadata.loadfile(str(metadata_file)) == json.dumps({
+        "id": 1234,
+        "location": "Room"
+    })
+
+
+def test_metadata_get_data_accepts_string_transmitter_id():
+    """
+    metadata.get_data converts a string transmitter id to int before lookup.
+    """
+    assert metadata.get_data(
+        "2345",
+        METADATA_TEST_FILE_OUTPUT
+    ) == METADATA_TEST_TRANSMITTER_OUTPUT

--- a/tests/test_mtr.py
+++ b/tests/test_mtr.py
@@ -1,42 +1,50 @@
 """
 Tests for MTR module
 """
-#import pytest
 
 import json
+
 from freezegun import freeze_time
 from mtr2mqtt import mtr
 
 
-MTR_READING_INPUT = '0 90 58 15006 145 11'
+MTR_READING_INPUT = "0 90 58 15006 145 11"
 MTR_READING_OUTPUT = json.dumps({
     "battery": 2.6,
     "type": "FT10",
     "rsl": -69,
     "id": "15006",
     "reading": 22.9,
-    "timestamp": "2020-09-23 19:34:13.497019+00:00"})
+    "timestamp": "2020-09-23 19:34:13.497019+00:00"
+})
 
-MTR_UNSUPPORTED_INPUT = '2 90 58 12345 145 11'
+MTR_UNSUPPORTED_INPUT = "2 90 58 12345 145 11"
 MTR_UNSUPPORTED_OUTPUT = json.dumps({
     "battery": 2.6,
     "type": "MTR262",
     "rsl": -69,
     "id": "12345",
     "message": "Unsupport transmitter type",
-    "timestamp": "2020-09-23 19:34:13.497019+00:00"})
+    "timestamp": "2020-09-23 19:34:13.497019+00:00"
+})
 
-MTR_CALIBRATION_INPUT ='15 124 45 27054 0 184 23'
+MTR_CALIBRATION_INPUT = "15 124 45 27054 0 184 23"
 MTR_CALIBRATION_OUTPUT = json.dumps({
     "battery": 2.8,
     "type": "UTILITY",
     "rsl": -82,
     "id": "27054",
     "calibrated": "16.08.2016",
-    "timestamp": "2020-09-23 19:34:13.497019+00:00"})
+    "timestamp": "2020-09-23 19:34:13.497019+00:00"
+})
 
+MTR_UTILITY_UNKNOWN_INPUT = "15 124 45 27054 1 184 23"
+MTR_DEVICE_NOT_CALIBRATED_INPUT = "15 124 45 27054 0 255 255"
 MTR_NONE_MESSAGE = None
-MTR_TOO_SHORT_INPUT = '0 90 58 15006'
+MTR_TOO_SHORT_INPUT = "0 90 58 15006"
+MTR_SIZE_MISMATCH_INPUT = "0 122 58 15006 145 11"
+MTR_CSR260_READING_INPUT = "11 90 58 15006 145 11"
+
 
 @freeze_time("2020-09-23 19:34:13.497019+00:00")
 def test_mtr_reading_response_to_json_with_sample_input():
@@ -45,12 +53,14 @@ def test_mtr_reading_response_to_json_with_sample_input():
     """
     assert mtr.mtr_response_to_json(MTR_READING_INPUT, None) == MTR_READING_OUTPUT
 
+
 @freeze_time("2020-09-23 19:34:13.497019+00:00")
 def test_mtr_reading_response_to_json_with_unsupported_input():
     """
     mtr.mtr_response_to_json returns error message formatted as json
     """
     assert mtr.mtr_response_to_json(MTR_UNSUPPORTED_INPUT, None) == MTR_UNSUPPORTED_OUTPUT
+
 
 @freeze_time("2020-09-23 19:34:13.497019+00:00")
 def test_mtr_calibdation_response_to_json_with_sample_input():
@@ -59,11 +69,13 @@ def test_mtr_calibdation_response_to_json_with_sample_input():
     """
     assert mtr.mtr_response_to_json(MTR_CALIBRATION_INPUT, None) == MTR_CALIBRATION_OUTPUT
 
+
 def test_check_payload_with_valid_message():
     """
     mtr.check_payload checks the validity of payload and returns boolean
     """
     assert mtr.check_payload(MTR_READING_INPUT)
+
 
 def test_check_payload_with_no_message():
     """
@@ -71,14 +83,129 @@ def test_check_payload_with_no_message():
     """
     assert not mtr.check_payload(MTR_NONE_MESSAGE)
 
+
 def test_check_payload_with_short_message():
     """
     mtr.check_payload checks the validity of payload and returns boolean
     """
     assert not mtr.check_payload(MTR_TOO_SHORT_INPUT)
 
+
+def test_check_payload_with_size_mismatch():
+    """
+    mtr.check_payload returns False when the payload length field does not match.
+    """
+    assert not mtr.check_payload(MTR_SIZE_MISMATCH_INPUT)
+
+
 def test_get_headers_with_valid_message():
     """
     mtr.get_headers returns header fields as tuple
     """
-    assert mtr._get_header_fields(MTR_READING_INPUT) == ('FT10', -69, '15006', 2.6)
+    assert mtr._get_header_fields(MTR_READING_INPUT) == ("FT10", -69, "15006", 2.6)
+
+
+def test_get_headers_returns_none_for_invalid_message():
+    """
+    mtr._get_header_fields returns None for invalid payloads.
+    """
+    assert mtr._get_header_fields(MTR_TOO_SHORT_INPUT) is None
+
+
+def test_get_ft10_reading_with_valid_message():
+    """
+    mtr._get_ft10_reading converts the payload bytes into a Celsius reading.
+    """
+    assert mtr._get_ft10_reading(MTR_READING_INPUT) == 22.9
+
+
+def test_get_ft10_reading_returns_none_for_invalid_message():
+    """
+    mtr._get_ft10_reading returns None for invalid payloads.
+    """
+    assert mtr._get_ft10_reading(MTR_TOO_SHORT_INPUT) is None
+
+
+@freeze_time("2020-09-23 19:34:13.497019+00:00")
+def test_mtr_response_to_json_with_metadata_merge():
+    """
+    Transmitter metadata is merged into the JSON payload when found.
+    """
+    transmitters_metadata = json.dumps([
+        {"id": 15006, "location": "Living room", "unit": "C"}
+    ])
+
+    assert mtr.mtr_response_to_json(MTR_READING_INPUT, transmitters_metadata) == json.dumps({
+        "battery": 2.6,
+        "type": "FT10",
+        "rsl": -69,
+        "id": "15006",
+        "reading": 22.9,
+        "timestamp": "2020-09-23 19:34:13.497019+00:00",
+        "location": "Living room",
+        "unit": "C"
+    })
+
+
+@freeze_time("2020-09-23 19:34:13.497019+00:00")
+def test_mtr_response_to_json_with_missing_metadata_keeps_original_payload():
+    """
+    Missing transmitter metadata does not change the produced JSON.
+    """
+    transmitters_metadata = json.dumps([
+        {"id": 99999, "location": "Elsewhere"}
+    ])
+
+    assert mtr.mtr_response_to_json(MTR_READING_INPUT, transmitters_metadata) == MTR_READING_OUTPUT
+
+
+@freeze_time("2020-09-23 19:34:13.497019+00:00")
+def test_mtr_response_to_json_with_unknown_utility_packet():
+    """
+    Unknown utility packets are returned with the stable utility marker.
+    """
+    assert mtr.mtr_response_to_json(MTR_UTILITY_UNKNOWN_INPUT, None) == json.dumps({
+        "battery": 2.8,
+        "type": "UTILITY",
+        "rsl": -82,
+        "id": "27054",
+        "utility": "Unknown utility packet",
+        "timestamp": "2020-09-23 19:34:13.497019+00:00"
+    })
+
+
+@freeze_time("2020-09-23 19:34:13.497019+00:00")
+def test_mtr_response_to_json_with_uncalibrated_utility_packet():
+    """
+    Utility calibration packets with 65535 days return the not-calibrated message.
+    """
+    assert mtr.mtr_response_to_json(MTR_DEVICE_NOT_CALIBRATED_INPUT, None) == json.dumps({
+        "battery": 2.8,
+        "type": "UTILITY",
+        "rsl": -82,
+        "id": "27054",
+        "message": "Device not calibrated",
+        "timestamp": "2020-09-23 19:34:13.497019+00:00"
+    })
+
+
+@freeze_time("2020-09-23 19:34:13.497019+00:00")
+def test_mtr_response_to_json_with_csr260_reading():
+    """
+    CSR260 payloads use the FT10 reading handler.
+    """
+    assert mtr.mtr_response_to_json(MTR_CSR260_READING_INPUT, None) == json.dumps({
+        "battery": 2.6,
+        "type": "CSR260",
+        "rsl": -69,
+        "id": "15006",
+        "reading": 22.9,
+        "timestamp": "2020-09-23 19:34:13.497019+00:00"
+    })
+
+
+def test_mtr_response_to_json_returns_none_for_invalid_message():
+    """
+    Invalid payloads are ignored.
+    """
+    assert mtr.mtr_response_to_json(MTR_TOO_SHORT_INPUT, None) is None

--- a/tests/test_scl.py
+++ b/tests/test_scl.py
@@ -1,34 +1,79 @@
 """
-Tests for MTR module
+Tests for SCL module
 """
-import pytest
-
 from context import mtr2mqtt
 from mtr2mqtt import scl
 
-SCL_COMMAND_MEA_CH_1_OUTPUT = b'\x81\x4D\x45\x41\x20\x43\x48\x20\x31\x20\x3F\x03\x6F'
-SCL_COMMAND_TYPE_OUTPUT = b'\x80TYPE ?\x03\x04'
+
+SCL_COMMAND_MEA_CH_1_OUTPUT = b"\x81\x4D\x45\x41\x20\x43\x48\x20\x31\x20\x3F\x03\x6F"
+SCL_COMMAND_TYPE_OUTPUT = b"\x80TYPE ?\x03\x04"
+SCL_VALID_RESPONSE = b"\x80TYPE MTR970\x03"
+SCL_VALID_RESPONSE_CHECKSUM = scl.calc_bcc(SCL_VALID_RESPONSE)
+
 
 def test_scl_bcc_with_correct_checksum():
     """
     scl.calc_bcc returns the checksum byte
     """
-    assert scl.calc_bcc(b'\x060 91 56 24859 169 11\x03') == b'\x12'
+    assert scl.calc_bcc(b"\x060 91 56 24859 169 11\x03") == b"\x12"
+
 
 def test_scl_command_creation_without_address():
     """
     scl.create_command returns the SCL command in bytes using default broadcast address
     """
-    assert scl.create_command('TYPE ?') == b'\xfeTYPE ?\x03\x04'
+    assert scl.create_command("TYPE ?") == b"\xfeTYPE ?\x03\x04"
+
 
 def test_scl_command_creation_with_address():
     """
     scl.create_command returns the SCL command in bytes using defined address
     """
-    assert scl.create_command('TYPE ?',0) == SCL_COMMAND_TYPE_OUTPUT
+    assert scl.create_command("TYPE ?", 0) == SCL_COMMAND_TYPE_OUTPUT
+
 
 def test_scl_mea_ch_command_creation_with_address():
     """
     scl.create_command returns the SCL command in bytes using defined address
     """
-    assert scl.create_command('MEA CH 1 ?',1) == SCL_COMMAND_MEA_CH_1_OUTPUT
+    assert scl.create_command("MEA CH 1 ?", 1) == SCL_COMMAND_MEA_CH_1_OUTPUT
+
+
+def test_scl_parse_response_with_valid_checksum():
+    """
+    scl.parse_response returns the payload string for valid ASCII responses.
+    """
+    assert scl.parse_response(
+        SCL_VALID_RESPONSE,
+        SCL_VALID_RESPONSE_CHECKSUM
+    ) == "TYPE MTR970"
+
+
+def test_scl_parse_response_returns_none_for_invalid_checksum():
+    """
+    scl.parse_response ignores responses with a checksum mismatch.
+    """
+    assert scl.parse_response(
+        SCL_VALID_RESPONSE,
+        b"\x00"
+    ) is None
+
+
+def test_scl_parse_response_returns_none_for_non_ascii_response():
+    """
+    scl.parse_response returns None when the payload cannot be decoded as ASCII.
+    """
+    invalid_ascii_response = b"\x80\xff\x03"
+    invalid_ascii_checksum = scl.calc_bcc(invalid_ascii_response)
+
+    assert scl.parse_response(
+        invalid_ascii_response,
+        invalid_ascii_checksum
+    ) is None
+
+
+def test_scl_calc_bcc_empty_message():
+    """
+    XOR checksum of an empty byte string is zero.
+    """
+    assert scl.calc_bcc(b"") == b"\x00"


### PR DESCRIPTION
## What this PR does

This PR expands the existing unit test suite with additional coverage for parser and helper behavior.

## Areas covered

- CLI parser behavior
- metadata lookup and edge cases
- MTR parsing edge cases
- SCL helper/parser edge cases

## Why this is needed

The repository workflows are now in a much better state, so the next priority is improving the safety net around the core Python logic. This PR adds more focused unit coverage without changing production behavior or expanding the scope into integration-style testing yet.

## Scope

This PR intentionally only changes test files under `tests/`.

It does not change:
- application code
- CI workflows
- release workflows
- Docker workflows
- packaging

## Expected result

After this PR:
- pytest covers more real parser/helper behavior
- edge cases are exercised better
- CI gets a stronger signal from the existing test job