### PR TITLE
fix(ci): tag docker image from semantic-release output

### DIFF
--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -1,14 +1,15 @@
 name: Docker Publish
 
 on:
-  workflow_run:
-    workflows:
-      - Semantic Release
-    types:
-      - completed
+  workflow_call:
+    inputs:
+      version:
+        description: Released version from semantic-release
+        required: true
+        type: string
 
 concurrency:
-  group: docker-publish-${{ github.event.workflow_run.head_branch }}
+  group: docker-publish-${{ github.ref }}
   cancel-in-progress: false
 
 permissions:
@@ -17,34 +18,17 @@ permissions:
 jobs:
   docker-publish:
     name: Build and publish Docker image
-    if: >
-      github.event.workflow_run.conclusion == 'success' &&
-      github.event.workflow_run.head_branch == 'master'
     runs-on: ubuntu-latest
 
     steps:
-      - name: Check out released commit
+      - name: Check out released source
         uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.workflow_run.head_sha }}
 
       - name: Determine image tags
         shell: bash
         run: |
-          VERSION=$(python - <<'PY'
-          import re
-          from pathlib import Path
-
-          content = Path("setup.py").read_text()
-          match = re.search(r'^__version__\s*=\s*"([^"]+)"', content, re.MULTILINE)
-          if not match:
-              raise SystemExit("Could not find __version__ in setup.py")
-          print(match.group(1))
-          PY
-          )
-
-          MAJOR_MINOR=$(echo "$VERSION" | cut -d. -f1,2)
-
+          VERSION="${{ inputs.version }}"
+          MAJOR_MINOR="$(echo "$VERSION" | cut -d. -f1,2)"
           echo "VERSION=$VERSION" >> "$GITHUB_ENV"
           echo "MAJOR_MINOR=$MAJOR_MINOR" >> "$GITHUB_ENV"
 

--- a/.github/workflows/semantic_release.yml
+++ b/.github/workflows/semantic_release.yml
@@ -16,6 +16,10 @@ jobs:
   release:
     name: Release to GitHub and PyPI
     runs-on: ubuntu-latest
+    outputs:
+      released: ${{ steps.release.outputs.released }}
+      version: ${{ steps.release.outputs.version }}
+      tag: ${{ steps.release.outputs.tag }}
 
     steps:
       - name: Check out repository
@@ -50,6 +54,7 @@ jobs:
 
           if [ "$BEFORE_TAG" != "$AFTER_TAG" ] && [ -n "$AFTER_TAG" ]; then
             semantic-release changelog
+
             if ! git diff --quiet -- CHANGELOG.md; then
               git add CHANGELOG.md
               git commit --amend --no-edit
@@ -57,6 +62,7 @@ jobs:
             fi
 
             git push origin HEAD:master --follow-tags --force
+
             echo "released=true" >> "$GITHUB_OUTPUT"
             echo "version=${AFTER_TAG#v}" >> "$GITHUB_OUTPUT"
             echo "tag=$AFTER_TAG" >> "$GITHUB_OUTPUT"
@@ -85,3 +91,12 @@ jobs:
           password: ${{ secrets.PYPI_TOKEN }}
           packages-dir: dist
           skip-existing: true
+
+  docker-publish:
+    name: Publish Docker image
+    needs: release
+    if: needs.release.outputs.released == 'true'
+    uses: ./.github/workflows/docker_publish.yml
+    with:
+      version: ${{ needs.release.outputs.version }}
+    secrets: inherit


### PR DESCRIPTION
## Summary

Fix Docker image tagging so the published image version comes directly from Semantic Release output instead of being derived from checked-out source code.

## Problem

The Docker publishing workflow was tagging images using the old version from repository state rather than the newly released version created when changes were merged to `master`.

That happened because Docker publishing used source checkout state to determine the version, which could still reflect the pre-release commit instead of the release version generated by Semantic Release.

## Changes

- converted `.github/workflows/docker_publish.yml` into a reusable workflow invoked with `workflow_call`
- added a required `version` input to the Docker publish workflow
- removed version parsing from repository files
- updated `.github/workflows/semantic_release.yml` to expose the release version as a job output
- added a dependent `docker-publish` job in `semantic_release.yml`
- passed `needs.release.outputs.version` into the Docker publish workflow
- kept Docker publishing conditional on an actual release being created

## Result

Docker image tags now match the exact version produced by Semantic Release for that release run.

## Testing

- reviewed workflow wiring so Docker publish only runs when `released == 'true'`
- verified Docker tag values now come from `${{ needs.release.outputs.version }}`
- verified `latest` and major/minor tags are still published alongside the full version tag