### PR TITLE
fix: switch PyPI publish to trusted publishing

### DIFF
--- a/.github/workflows/semantic_release.yml
+++ b/.github/workflows/semantic_release.yml
@@ -11,11 +11,13 @@ concurrency:
 
 permissions:
   contents: write
+  id-token: write
 
 jobs:
   release:
     name: Release to GitHub and PyPI
     runs-on: ubuntu-latest
+    environment: pypi
     outputs:
       released: ${{ steps.release.outputs.released }}
       version: ${{ steps.release.outputs.version }}
@@ -75,8 +77,6 @@ jobs:
         if: steps.release.outputs.released == 'true'
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          user: __token__
-          password: ${{ secrets.PYPI_TOKEN }}
           packages-dir: dist
           skip-existing: true
 


### PR DESCRIPTION
## What this PR does

This PR switches the Python release workflow from token-based PyPI authentication to PyPI Trusted Publishing using GitHub Actions OIDC.

## Changes made

- adds `id-token: write` permission to the release workflow
- adds `environment: pypi` to the release job
- removes `PYPI_TOKEN`-based authentication from the PyPI publish step
- keeps the existing release flow otherwise unchanged

## Why this is needed

The current release workflow still relies on a long-lived PyPI token secret.

Trusted Publishing replaces that with short-lived credentials issued through GitHub Actions OIDC, which is the recommended model for PyPI publishing.

## Scope

This PR changes only:
- `.github/workflows/semantic_release.yml`

This PR does not change:
- application code
- packaging metadata
- CI workflow
- Docker publish workflow
- Trivy workflow

## PyPI setup required before merge

Before merging, configure a Trusted Publisher in the existing PyPI project with these exact values:

- GitHub owner: `tvallas`
- repository: `mtr2mqtt`
- workflow file: `.github/workflows/semantic_release.yml`
- environment: `pypi`

## Expected result

After PyPI Trusted Publisher setup is in place and this PR is merged:
- releases will publish to PyPI without `PYPI_TOKEN`
- GitHub Actions will use OIDC-based short-lived credentials
- the existing release and Docker publish flow will otherwise continue to behave the same