### PR TITLE
fix(ci): remove duplicate GitHub release creation

### DIFF
--- a/.github/workflows/semantic_release.yml
+++ b/.github/workflows/semantic_release.yml
@@ -64,15 +64,6 @@ jobs:
             echo "released=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Create GitHub Release
-        if: steps.release.outputs.released == 'true'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          gh release create "${{ steps.release.outputs.tag }}" \
-            --generate-notes \
-            --title "${{ steps.release.outputs.tag }}"
-
       - name: Publish to PyPI
         if: steps.release.outputs.released == 'true'
         uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
## What this PR does

This PR fixes the Python release workflow by removing the duplicate manual GitHub Release creation step from `.github/workflows/semantic_release.yml`.

The workflow was failing after semantic-release had already created the release tag because the later `gh release create` step tried to create the same release again.

This PR also keeps the PyPI Trusted Publishing configuration in place.

## Changes made

- removes the separate `Create GitHub Release` step

## Why this is needed

The failing run showed that `uv run semantic-release version` successfully calculated and created version `0.6.3`, but the workflow then failed on:

- `gh release create "v0.6.3"`
- `HTTP 422: Validation Failed`
- `Release.tag_name already exists`

So the failure was caused by duplicate GitHub release creation, not by PyPI Trusted Publishing.

## Scope

This PR changes only:
- `.github/workflows/semantic_release.yml`

This PR does not change:
- application code
- packaging metadata
- CI workflow
- Docker publish workflow
- Trivy workflow

## PyPI setup

Trusted Publisher setup has already been configured for the existing PyPI project with:

- GitHub owner: `tvallas`
- repository: `mtr2mqtt`
- workflow file: `.github/workflows/semantic_release.yml`
- environment: `pypi`

## Expected result

After this PR is merged:
- semantic-release will continue handling versioning, tagging, changelog, build, and push
- the workflow will stop failing on duplicate GitHub release creation
- PyPI publishing will use OIDC Trusted Publishing instead of `PYPI_TOKEN`
- Docker publish chaining will continue to work as before