### PR TITLE
fix(ci): switch release workflow to python-semantic-release action

### DIFF
--- a/.github/workflows/semantic_release.yml
+++ b/.github/workflows/semantic_release.yml
@@ -29,40 +29,11 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.11"
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@v7
-        with:
-          enable-cache: true
-
-      - name: Sync dependencies
-        run: uv sync --group dev
-
-      - name: Configure git author
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-
       - name: Create release version, changelog, build, and push
         id: release
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          BEFORE_TAG="$(git describe --tags --abbrev=0 2>/dev/null || true)"
-          uv run semantic-release version
-          AFTER_TAG="$(git describe --tags --abbrev=0 2>/dev/null || true)"
-
-          if [ "$BEFORE_TAG" != "$AFTER_TAG" ] && [ -n "$AFTER_TAG" ]; then
-            echo "released=true" >> "$GITHUB_OUTPUT"
-            echo "version=${AFTER_TAG#v}" >> "$GITHUB_OUTPUT"
-            echo "tag=$AFTER_TAG" >> "$GITHUB_OUTPUT"
-          else
-            echo "released=false" >> "$GITHUB_OUTPUT"
-          fi
+        uses: python-semantic-release/python-semantic-release@v10.5.3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Publish to PyPI
         if: steps.release.outputs.released == 'true'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,8 @@ tag_format = "v{version}"
 commit_message = "chore(release): {version}"
 version_toml = ["pyproject.toml:project.version"]
 build_command = """
-uv lock
+python -m pip install "uv>=0.11,<0.12"
+uv lock --upgrade-package "$PACKAGE_NAME"
 git add uv.lock
 rm -rf dist
 uv build


### PR DESCRIPTION
## What this PR does

This PR switches the Python release workflow from a custom shell-based `uv run semantic-release version` step to the official `python-semantic-release` GitHub Action.

## Changes made

- replaces the manual semantic-release shell step with `python-semantic-release/python-semantic-release`
- removes the manual git author configuration step
- keeps PyPI Trusted Publishing in place
- keeps the existing release trigger
- keeps the existing Docker publish chaining
- updates `build_command` in `pyproject.toml` so it works correctly with the PSR GitHub Action Docker environment
- keeps `uv.lock` refresh and staging as part of the release build flow

## Why this is needed

The current workflow has been more manual than necessary and has already needed custom logic around tag detection, release handling, and git identity.

The official PSR action is simpler to maintain and is designed for this exact use case.

A small `pyproject.toml` change is also required because the PSR GitHub Action runs in a Docker environment that does not include `uv` by default, while this project’s release build uses `uv`.

## Scope

This PR changes only:
- `.github/workflows/semantic_release.yml`
- `pyproject.toml`

This PR does not change:
- application code
- CI workflow
- Docker publish workflow
- Trivy workflow
- README

## Expected result

After this PR is merged:
- semantic-release versioning and VCS release handling will be managed by the official PSR GitHub Action
- PyPI publishing will continue to use Trusted Publishing
- `uv.lock` will continue to be refreshed as part of the release flow
- Docker publish chaining will continue to work as before