### PR TITLE
fix(changelog): move semantic-release marker above legacy entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+<!-- version list -->
+
+## Legacy changelog
+
 ## v0.6.4 (2026-04-16)
 
 ### Bug Fixes


### PR DESCRIPTION
## What this PR does

This PR restructures `CHANGELOG.md` so `python-semantic-release` can keep adding the newest generated entries at the top of the file while preserving the existing legacy changelog content below.

## Changes made

- keeps the standard changelog heading
- places the semantic-release insertion marker directly under the heading:
  - `<!-- version list -->`
- preserves the legacy/manual changelog content below the marker

## Why this is needed

`python-semantic-release` is using changelog update mode, which inserts new release content at the configured insertion flag.

By placing the marker near the top of the file, new release entries stay at the top where they are easiest to read, while the old legacy content remains preserved underneath.

## Scope

This PR changes only:
- `CHANGELOG.md`

## Expected result

After this PR is merged, the next semantic-release run should insert the new generated changelog entry near the top of the file instead of leaving the changelog unchanged or forcing the newest content to the bottom.