### PR TITLE
ci: modernize Trivy security scanning workflow

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -1,4 +1,4 @@
-name: Scan
+name: Trivy
 
 on:
   push:
@@ -6,40 +6,69 @@ on:
       - master
   pull_request:
 
+concurrency:
+  group: trivy-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  security-events: write
+
 jobs:
-  scan:
-    name: Scan
+  trivy:
+    name: Trivy scan
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout code
+      - name: Check out repository
         uses: actions/checkout@v4
+
+      - name: Run Trivy filesystem scan
+        id: trivy_fs
+        uses: aquasecurity/trivy-action@0.35.0
+        continue-on-error: true
         with:
-          fetch-depth: 0
-
-      - name: Set up Python 3.10
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.10"
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@v7
-        with:
-          enable-cache: true
-
-      - name: Sync dependencies
-        run: uv sync --group dev
-
-      - name: Build an image from Dockerfile
-        run: |
-          docker build -t tvallas/mtr2mqtt:${GITHUB_SHA} .
-
-      - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@master
-        with:
-          image-ref: tvallas/mtr2mqtt:${{ github.sha }}
-          format: table
-          exit-code: "1"
+          scan-type: fs
+          scan-ref: .
+          format: sarif
+          output: trivy-fs.sarif
+          severity: HIGH,CRITICAL
           ignore-unfixed: true
-          vuln-type: os,library
-          severity: CRITICAL,HIGH
+          exit-code: 1
+
+      - name: Upload filesystem scan results to GitHub Security
+        if: always()
+        uses: github/codeql-action/upload-sarif@v4
+        with:
+          sarif_file: trivy-fs.sarif
+          category: trivy-fs
+
+      - name: Build Docker image
+        run: docker build -t mtr2mqtt:trivy-${{ github.sha }} .
+
+      - name: Run Trivy image scan
+        id: trivy_image
+        uses: aquasecurity/trivy-action@0.35.0
+        continue-on-error: true
+        with:
+          image-ref: mtr2mqtt:trivy-${{ github.sha }}
+          format: sarif
+          output: trivy-image.sarif
+          severity: HIGH,CRITICAL
+          ignore-unfixed: true
+          exit-code: 1
+
+      - name: Upload image scan results to GitHub Security
+        if: always()
+        uses: github/codeql-action/upload-sarif@v4
+        with:
+          sarif_file: trivy-image.sarif
+          category: trivy-image
+
+      - name: Fail if Trivy found HIGH or CRITICAL vulnerabilities
+        if: always()
+        run: |
+          if [ "${{ steps.trivy_fs.outcome }}" != "success" ] || [ "${{ steps.trivy_image.outcome }}" != "success" ]; then
+            echo "Trivy detected HIGH or CRITICAL vulnerabilities."
+            exit 1
+          fi


### PR DESCRIPTION
## Summary

Modernize the standalone Trivy workflow so it is a stable, focused security scan for both the repository and the built Docker image.

## Changes

- keep `Trivy` as a separate workflow
- keep triggers on:
  - push to `master`
  - pull_request
- add top-level concurrency control
- add explicit workflow permissions:
  - `contents: read`
  - `security-events: write`
- replace `aquasecurity/trivy-action@master` with a stable tagged release
- scan the repository filesystem / dependency tree with Trivy
- build the local Docker image and scan that image with Trivy
- upload both scan results to GitHub Security as separate SARIF categories
- preserve failure behavior for HIGH/CRITICAL findings while still uploading SARIF results

## Notes

This PR intentionally modifies only `.github/workflows/trivy.yml`.