### PR TITLE
fix: allow docker publish attestations from semantic release

### DIFF
--- a/.github/workflows/semantic_release.yml
+++ b/.github/workflows/semantic_release.yml
@@ -10,7 +10,8 @@ concurrency:
   cancel-in-progress: false
 
 permissions:
-  contents: write
+  contents: read
+  attestations: write
   id-token: write
 
 jobs:


### PR DESCRIPTION
## Summary

Allow the semantic release workflow to call the reusable Docker publish workflow after the Docker publish job was hardened to request attestation-related permissions.

## Changes

- add the required GitHub Actions permissions to `.github/workflows/semantic_release.yml`:
  - `contents: read`
  - `attestations: write`
  - `id-token: write`

## Why

The reusable `docker_publish.yml` workflow now requests attestation-related permissions for provenance/SBOM publishing. The caller workflow must explicitly allow those permissions, otherwise GitHub rejects the reusable workflow call during validation.

This PR fixes that permission mismatch.

## Scope

- only updates `.github/workflows/semantic_release.yml`
- no changes to release logic
- no changes to Docker image tags or publish behavior
- no application code changes