### PR TITLE
chore(ci): expand Python version coverage in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,8 @@ jobs:
         python-version:
           - "3.10"
           - "3.11"
+          - "3.12"
+          - "3.13"
 
     steps:
       - name: Check out repository


### PR DESCRIPTION
## What this PR does

This PR broadens CI runtime coverage by expanding the Python version matrix in the main CI workflow.

## Changes made

- updates the Python matrix in `.github/workflows/ci.yml`
- keeps the existing CI workflow structure unchanged otherwise

## Why this is needed

The project declares its supported Python range in `pyproject.toml`, and CI should validate against that full supported CPython range rather than only a subset.

`pyproject.toml` currently declares:

- `requires-python = ">=3.10"`

Based on that, the CI matrix is expanded to cover:

- 3.10
- 3.11
- 3.12
- 3.13

## Scope

This PR changes only:

- `.github/workflows/ci.yml`

This PR does not change:

- application code
- tests
- packaging metadata
- release workflow
- Docker workflows
- Trivy workflow

## Expected result

After this PR:

- CI will run lint, tests, and package build across the full supported CPython minor-version range declared by the project
- runtime compatibility regressions across supported Python versions will be caught earlier