### PR TITLE
chore(deps): add Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,53 @@
+version: 2
+
+updates:
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "python"
+    commit-message:
+      prefix: "fix(deps)"
+    groups:
+      python-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 3
+    labels:
+      - "dependencies"
+      - "github-actions"
+    commit-message:
+      prefix: "chore(deps)"
+    groups:
+      actions-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 2
+    labels:
+      - "dependencies"
+      - "docker"
+    commit-message:
+      prefix: "fix(deps)"
+    groups:
+      docker-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
## What this PR does

This PR adds a repository-level Dependabot configuration.

## Changes made

- adds `.github/dependabot.yml`
- enables Dependabot updates for:
  - `uv`
  - `github-actions`
  - `docker`
- groups minor and patch updates to reduce PR noise
- adds dependency labels
- uses a conventional commit-style prefix for Dependabot PRs

## Why this is needed

Dependabot is more useful when it is configured explicitly in the repository instead of relying on partial or default behavior.

This setup makes dependency updates cover the main moving parts in this project:
- Python dependencies
- GitHub Actions
- Docker base image updates

## Scope

This PR only adds:
- `.github/dependabot.yml`

It does not change:
- application code
- workflows
- packaging
- release behavior
- Docker publish behavior

## Expected result

After this PR:
- Dependabot can open PRs for uv dependency updates
- Dependabot can open PRs for GitHub Actions updates
- Dependabot can open PRs for Docker base image updates
- PR volume stays manageable through grouping and PR limits