### PR TITLE
fix: update MQTT client to callback API v2

### DIFF
--- a/mtr2mqtt/cli.py
+++ b/mtr2mqtt/cli.py
@@ -212,25 +212,33 @@ def _get_latest_from_ring_buffer(ser, scl_dbg_1_command, serial_config):
             time.sleep(1)
     return parsed_response
 
-def on_connect(client, userdata, flags, connection_result):
+def on_connect(client, userdata, flags, reason_code, properties):
     """"
     Handles actions on MQTT connect
     """
-    logging.debug("userdata: %s, flags: %s", userdata, flags)
-    if connection_result==0:
+    logging.debug(
+        "userdata: %s, flags: %s, properties: %s",
+        userdata,
+        flags,
+        properties,
+    )
+    if reason_code == 0:
         client.connected_flag = True #set flag
         logging.info("MQTT server connected OK")
     else:
-        logging.warning("Bad connection Returned code=%s",str(connection_result))
+        logging.warning("Bad connection Returned code=%s", str(reason_code))
 
-def on_disconnect(client, userdata, connection_result):
+def on_disconnect(client, userdata, disconnect_flags, reason_code, properties):
     """"
     Handles actions on MQTT disconnect
     """
     logging.warning(
-        "MQTT server disconnected with reason: %s, userdata: %s",
-        str(connection_result), userdata
-        )
+        "MQTT server disconnected with reason: %s, userdata: %s, flags: %s, properties: %s",
+        str(reason_code),
+        userdata,
+        disconnect_flags,
+        properties,
+    )
     client.connected_flag=False
     client.disconnect_flag=True
 
@@ -240,12 +248,12 @@ def _open_mqtt_connection(args):
     """
 
     mqtt.Client.connected_flag = False #create flag in class
-    # Update the client initialization to specify callback API version
     client = mqtt.Client(
-    client_id='mtr2mqtt',
-    userdata=None,
-    protocol=mqtt.MQTTv311,
-    transport="tcp"
+        callback_api_version=mqtt.CallbackAPIVersion.VERSION2,
+        client_id='mtr2mqtt',
+        userdata=None,
+        protocol=mqtt.MQTTv311,
+        transport="tcp"
     )
     client.enable_logger()
     client.on_connect = on_connect

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,6 +1,8 @@
 """
 Tests for cli module
 """
+from types import SimpleNamespace
+
 import pytest
 from context import mtr2mqtt
 from mtr2mqtt import cli
@@ -146,3 +148,47 @@ def test_parser_rejects_invalid_scl_address():
 
     with pytest.raises(SystemExit):
         parser.parse_args(["--scl-address", "124"])
+
+
+def test_open_mqtt_connection_uses_callback_api_v2(monkeypatch):
+    """
+    MQTT client initialization opts in to the non-deprecated callback API.
+    """
+    captured = {}
+
+    class FakeClient:
+        def __init__(self, **kwargs):
+            captured["kwargs"] = kwargs
+            self.connected_flag = False
+
+        def enable_logger(self):
+            captured["enable_logger"] = True
+
+        def loop_start(self):
+            captured["loop_start"] = True
+
+        def connect(self, host, port):
+            captured["connect"] = (host, port)
+            self.connected_flag = True
+
+    monkeypatch.setattr(cli.mqtt, "Client", FakeClient)
+    monkeypatch.setattr(
+        cli.mqtt,
+        "CallbackAPIVersion",
+        SimpleNamespace(VERSION2="version2"),
+    )
+    monkeypatch.setattr(cli.time, "sleep", lambda _: None)
+
+    args = SimpleNamespace(mqtt_host="mqtt.example", mqtt_port=1884)
+
+    client = cli._open_mqtt_connection(args)
+
+    assert captured["kwargs"]["callback_api_version"] == "version2"
+    assert captured["kwargs"]["client_id"] == "mtr2mqtt"
+    assert captured["kwargs"]["protocol"] == cli.mqtt.MQTTv311
+    assert captured["kwargs"]["transport"] == "tcp"
+    assert captured["connect"] == ("mqtt.example", 1884)
+    assert captured["enable_logger"] is True
+    assert captured["loop_start"] is True
+    assert client.on_connect is cli.on_connect
+    assert client.on_disconnect is cli.on_disconnect


### PR DESCRIPTION
## Summary
- switch the MQTT client initialization to paho-mqtt callback API v2
- update connect and disconnect callbacks to the current paho-mqtt signatures
- add a regression test covering MQTT client initialization options

## Testing
- UV_CACHE_DIR=/tmp/uv-cache uv run pytest
