### PR TITLE
feat: add Home Assistant MQTT discovery support

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ A CLI tool for reading Nokeval MTR wireless receivers and forwarding readings as
 
 mtr2mqtt connects to Nokeval MTR series wireless receivers (such as RTR970, FTR980, etc.) via serial connection, reads the measurements from wireless transmitters, and publishes the data to MQTT topics in a structured JSON format.
 
+It can also publish Home Assistant MQTT Discovery messages so that each detected transmitter appears automatically as a Home Assistant device with `reading`, `battery`, and `rsl` sensor entities.
+
 ## Installation
 
 ### Using pip
@@ -30,6 +32,18 @@ Or define the serial port and mqtt host as parameters:
 
 ```sh
 mtr2mqtt --serial-port /dev/ttyUSB12345 --mqtt-host 192.168.1.2
+```
+
+Enable Home Assistant discovery:
+
+```sh
+mtr2mqtt -f metadata.yml --ha-discovery
+```
+
+Use a custom discovery prefix or node id:
+
+```sh
+mtr2mqtt --ha-discovery --ha-discovery-prefix ha --ha-discovery-node-id mtr-bridge-1
 ```
 
 ### Using Docker
@@ -105,12 +119,17 @@ The `metadata.yml` file is used to provide additional configuration for the `mtr
 The `metadata.yml` file should be structured as follows:
 
 ```yaml
-sensors:
 - id: 12345
   location: "Living room"
   description: "Ambient air temperature"
   unit: "°C"
   quantity: "Temperature"
+  ha:
+    name: "Ambient"
+    device_class: "temperature"
+    state_class: "measurement"
+    suggested_display_precision: 1
+    icon: "mdi:thermometer"
 - id: 54321
   location: "Living room"
   unit: "%"
@@ -121,10 +140,12 @@ sensors:
 Each sensor entry should include:
 
 - `id`: A unique identifier for the sensor.
-- `name`: A descriptive name for the sensor.
+- `description`: A descriptive label for the sensor.
 - `unit`: The unit of measurement for the sensor's readings.
 
 **Note:** Other metadata fields can be freely added and those are added to the JSON object.
+
+The optional `ha:` block is used only for Home Assistant discovery customization. It can override the main reading entity metadata with fields such as `name`, `device_class`, `state_class`, `suggested_display_precision`, and `icon`. Existing metadata files continue to work unchanged.
 
 ### Using the metadata file
 
@@ -147,6 +168,60 @@ measurements/<receiver_serial_number>/<sensor_id>
 ```
 
 Where `<receiver_serial_number>` is the serial number of the receiver and `<sensor_id>` is the unique identifier for the sensor.
+
+This measurement topic structure remains unchanged even when Home Assistant discovery is enabled.
+
+### Home Assistant MQTT Discovery
+
+When `--ha-discovery` is enabled, mtr2mqtt publishes retained Home Assistant device discovery messages the first time it sees a real measurement for a transmitter. One Home Assistant device is created per physical transmitter, using the transmitter id as the Home Assistant device identifier and entity unique id base. The MQTT state topic itself remains unchanged and still includes the receiver serial number.
+
+Discovery creates these entities for each transmitter:
+
+- `reading`: the primary sensor entity
+- `battery`: a diagnostic battery voltage sensor
+- `rsl`: a diagnostic signal sensor
+
+Discovery topics use Home Assistant device discovery:
+
+```text
+<discovery_prefix>/device/<object_id>/config
+<discovery_prefix>/device/<node_id>/<object_id>/config
+```
+
+For example:
+
+```text
+homeassistant/device/15006/config
+measurements/RTR970123/15006
+```
+
+The discovery payload points each entity to the existing measurement topic, so measurement payloads continue to be published as non-retained JSON messages.
+
+The primary reading entity also exposes the measurement JSON as Home Assistant attributes using `json_attributes_topic`, which means metadata fields such as `location`, `description`, `quantity`, and `zone` are visible in Home Assistant automatically.
+
+#### Home Assistant discovery configuration
+
+CLI flags:
+
+- `--ha-discovery`: enable Home Assistant discovery
+- `--ha-discovery-prefix`: set the discovery prefix, default `homeassistant`
+- `--ha-discovery-retain` and `--no-ha-discovery-retain`: control retained discovery messages, default retained
+- `--ha-discovery-node-id`: add an optional node id segment to the discovery topic
+
+Environment variables:
+
+- `MTR2MQTT_HA_DISCOVERY`
+- `MTR2MQTT_HA_DISCOVERY_PREFIX`
+- `MTR2MQTT_HA_DISCOVERY_RETAIN`
+- `MTR2MQTT_HA_DISCOVERY_NODE_ID`
+
+The reading entity infers conservative Home Assistant metadata from the existing metadata file when possible. For example, `quantity: Temperature` or `unit: °C` maps to `device_class: temperature`, humidity-like metadata maps to `device_class: humidity`, and pressure-like metadata maps to `device_class: pressure`.
+
+To align better with typical Home Assistant sensor setups, the primary reading entity also publishes:
+
+- `expire_after: 900`
+- `suggested_area` from metadata `location`
+- a default icon inferred from the measurement type, unless overridden in metadata `ha:`
 
 ### Message Format
 

--- a/mtr2mqtt/cli.py
+++ b/mtr2mqtt/cli.py
@@ -7,8 +7,9 @@ Functions
     main()
 
 """
+
 from importlib.metadata import version
-from argparse import ArgumentParser
+from argparse import ArgumentParser, BooleanOptionalAction
 import logging
 import sys
 import time
@@ -21,6 +22,17 @@ import serial
 from mtr2mqtt import scl
 from mtr2mqtt import mtr
 from mtr2mqtt import metadata
+from mtr2mqtt import homeassistant
+
+
+def _env_flag(name, default=False):
+    """
+    Parse a boolean environment variable with a fallback default.
+    """
+    value = os.environ.get(name)
+    if value is None:
+        return default
+    return value.lower() in ["true", "1", "yes", "on"]
 
 
 def create_parser():
@@ -33,28 +45,30 @@ def create_parser():
     """)
 
     parser.add_argument(
-        "--serial-port", '-s',
+        "--serial-port",
+        "-s",
         help="Serial port for MTR series receiver (ENV: MTR2MQTT_SERIAL_PORT)",
-        default=os.environ.get('MTR2MQTT_SERIAL_PORT'),
-        required=False
-        )
+        default=os.environ.get("MTR2MQTT_SERIAL_PORT"),
+        required=False,
+    )
     parser.add_argument(
         "--baudrate",
         help="Serial port baud rate",
-        default=int(os.environ.get('MTR2MQTT_BAUDRATE', 9600)),
+        default=int(os.environ.get("MTR2MQTT_BAUDRATE", 9600)),
         required=False,
         type=int,
-        choices=[9600, 115200]
-        )
+        choices=[9600, 115200],
+    )
     parser.add_argument(
         "--bytesize",
         help="Serial port byte size",
         default=EIGHTBITS,
         required=False,
-        choices=[FIVEBITS, SIXBITS,SEVENBITS, EIGHTBITS]
-        )
+        choices=[FIVEBITS, SIXBITS, SEVENBITS, EIGHTBITS],
+    )
     parser.add_argument(
-        "--parity", help="Serial port parity",
+        "--parity",
+        help="Serial port parity",
         default=serial.PARITY_NONE,
         required=False,
         choices=[
@@ -62,69 +76,107 @@ def create_parser():
             serial.PARITY_EVEN,
             serial.PARITY_ODD,
             serial.PARITY_MARK,
-            serial.PARITY_SPACE
-            ]
-        )
+            serial.PARITY_SPACE,
+        ],
+    )
     parser.add_argument(
         "--stopbits",
         help="Serial port stop bits",
         default=serial.STOPBITS_ONE,
         required=False,
-        choices=[serial.STOPBITS_ONE, serial.STOPBITS_TWO]
-        )
+        choices=[serial.STOPBITS_ONE, serial.STOPBITS_TWO],
+    )
     parser.add_argument(
         "--serial-timeout",
         help="Timeout for serial port (ENV: MTR2MQTT_SERIAL_TIMEOUT)",
-        default=int(os.environ.get('MTR2MQTT_SERIAL_TIMEOUT', 1)),
-        required=False
-        )
+        default=int(os.environ.get("MTR2MQTT_SERIAL_TIMEOUT", 1)),
+        required=False,
+    )
     parser.add_argument(
         "--scl-address",
         help="SCL address 0...123 or 126 for broadcast (ENV: MTR2MQTT_SCL_ADDRESS)",
-        default=int(os.environ.get('MTR2MQTT_SCL_ADDRESS', 126)),
+        default=int(os.environ.get("MTR2MQTT_SCL_ADDRESS", 126)),
         required=False,
         type=int,
-        choices=(list(range(124))+[126]),
-        metavar='' # for hiding the messy choices output
-        )
+        choices=(list(range(124)) + [126]),
+        metavar="",  # for hiding the messy choices output
+    )
     parser.add_argument(
-        "--mqtt-host", '-m',
+        "--mqtt-host",
+        "-m",
         help="MQTT host address (ENV: MTR2MQTT_MQTT_HOST)",
-        default=os.environ.get('MTR2MQTT_MQTT_HOST'),
-        required=False)
-    parser.add_argument(
-        "--mqtt-port", '-p',
-        help="MQTT host port (ENV: MTR2MQTT_MQTT_PORT)",
-        default=int(os.environ.get('MTR2MQTT_MQTT_PORT', 1883)),
-        required=False)
-    parser.add_argument(
-        "--metadata-file",'-f',
-        help="A file for transmitter metadata (ENV: MTR2MQTT_METADATA_FILE)",
-        default=os.environ.get('MTR2MQTT_METADATA_FILE'),
+        default=os.environ.get("MTR2MQTT_MQTT_HOST"),
         required=False,
-        type=str
-        )
+    )
+    parser.add_argument(
+        "--mqtt-port",
+        "-p",
+        help="MQTT host port (ENV: MTR2MQTT_MQTT_PORT)",
+        default=int(os.environ.get("MTR2MQTT_MQTT_PORT", 1883)),
+        required=False,
+    )
+    parser.add_argument(
+        "--metadata-file",
+        "-f",
+        help="A file for transmitter metadata (ENV: MTR2MQTT_METADATA_FILE)",
+        default=os.environ.get("MTR2MQTT_METADATA_FILE"),
+        required=False,
+        type=str,
+    )
+    parser.add_argument(
+        "--ha-discovery",
+        help="Enable Home Assistant MQTT discovery " "(ENV: MTR2MQTT_HA_DISCOVERY)",
+        default=_env_flag("MTR2MQTT_HA_DISCOVERY", False),
+        action=BooleanOptionalAction,
+        required=False,
+    )
+    parser.add_argument(
+        "--ha-discovery-prefix",
+        help="Home Assistant discovery prefix " "(ENV: MTR2MQTT_HA_DISCOVERY_PREFIX)",
+        default=os.environ.get("MTR2MQTT_HA_DISCOVERY_PREFIX", "homeassistant"),
+        required=False,
+        type=str,
+    )
+    parser.add_argument(
+        "--ha-discovery-retain",
+        help="Retain Home Assistant discovery payloads "
+        "(ENV: MTR2MQTT_HA_DISCOVERY_RETAIN)",
+        default=_env_flag("MTR2MQTT_HA_DISCOVERY_RETAIN", True),
+        action=BooleanOptionalAction,
+        required=False,
+    )
+    parser.add_argument(
+        "--ha-discovery-node-id",
+        help="Optional node id namespace for Home Assistant discovery "
+        "(ENV: MTR2MQTT_HA_DISCOVERY_NODE_ID)",
+        default=os.environ.get("MTR2MQTT_HA_DISCOVERY_NODE_ID"),
+        required=False,
+        type=str,
+    )
     group = parser.add_mutually_exclusive_group()
     group.add_argument(
-        "--debug", '-d',
+        "--debug",
+        "-d",
         help="Enable pringing debug messages (ENV: MTR2MQTT_DEBUG)",
         required=False,
-        default=os.environ.get('MTR2MQTT_DEBUG', 'False').lower() in ['true', '1'],
-        action='store_true'
-        )
+        default=os.environ.get("MTR2MQTT_DEBUG", "False").lower() in ["true", "1"],
+        action="store_true",
+    )
     group.add_argument(
-        "--quiet", '-q',
+        "--quiet",
+        "-q",
         help="Print only error messages (ENV: MTR2MQTT_QUIET)",
         required=False,
-        default=os.environ.get('MTR2MQTT_QUIET', 'False').lower() in ['true', '1'],
-        action='store_true'
-        )
+        default=os.environ.get("MTR2MQTT_QUIET", "False").lower() in ["true", "1"],
+        action="store_true",
+    )
     group.add_argument(
-        "--version", "-v",
+        "--version",
+        "-v",
         help="Print the mtr2mqtt version number and exit",
         required=False,
         default=False,
-        action='store_true'
+        action="store_true",
     )
 
     return parser
@@ -137,7 +189,7 @@ def _open_receiver_port(args):
 
     # Trying to find MTR compatible receiver
     # Filtering ports with Nokeval manufactured models that MTR receivers might use
-    serial_ports = list(list_ports.grep('RTR|FTR|DCS|DPR'))
+    serial_ports = list(list_ports.grep("RTR|FTR|DCS|DPR"))
 
     ser = serial.Serial()
 
@@ -150,10 +202,10 @@ def _open_receiver_port(args):
                 bytesize=args.bytesize,
                 parity=args.parity,
                 stopbits=args.stopbits,
-                timeout=args.serial_timeout
-                )
+                timeout=args.serial_timeout,
+            )
             if ser.is_open:
-                device_type = scl.get_receiver_type(ser,args.scl_address)
+                device_type = scl.get_receiver_type(ser, args.scl_address)
                 if device_type:
                     print(f"Connected device type: {device_type}")
         except serial.serialutil.SerialException:
@@ -171,18 +223,19 @@ def _open_receiver_port(args):
                     bytesize=args.bytesize,
                     parity=args.parity,
                     stopbits=args.stopbits,
-                    timeout=args.serial_timeout
-                    )
+                    timeout=args.serial_timeout,
+                )
                 if ser.is_open:
-                    device_type = scl.get_receiver_type(ser,args.scl_address)
+                    device_type = scl.get_receiver_type(ser, args.scl_address)
                     if device_type:
                         print(f"Connected device type: {device_type}")
             except serial.serialutil.SerialException:
                 pass
     return ser
 
+
 def _get_latest_from_ring_buffer(ser, scl_dbg_1_command, serial_config):
-    """"
+    """ "
     Get latest packet from MTR receiver ring buffer
     """
     try:
@@ -190,8 +243,10 @@ def _get_latest_from_ring_buffer(ser, scl_dbg_1_command, serial_config):
         logging.debug("Wrote message: %s to: to %s", scl_dbg_1_command, ser.name)
         response = ser.read_until(scl.END_CHAR)
         response_checksum = bytes(ser.read(1))
-        parsed_response = scl.parse_response(response,response_checksum)
-        logging.debug("response: %s, response checksum: %s", response, response_checksum)
+        parsed_response = scl.parse_response(response, response_checksum)
+        logging.debug(
+            "response: %s, response checksum: %s", response, response_checksum
+        )
         logging.debug("parsed SCL response: %s", parsed_response)
     except OSError:
         logging.exception("OS Error: Reading to serial port failed")
@@ -212,8 +267,9 @@ def _get_latest_from_ring_buffer(ser, scl_dbg_1_command, serial_config):
             time.sleep(1)
     return parsed_response
 
+
 def on_connect(client, userdata, flags, reason_code, properties):
-    """"
+    """ "
     Handles actions on MQTT connect
     """
     logging.debug(
@@ -223,13 +279,14 @@ def on_connect(client, userdata, flags, reason_code, properties):
         properties,
     )
     if reason_code == 0:
-        client.connected_flag = True #set flag
+        client.connected_flag = True  # set flag
         logging.info("MQTT server connected OK")
     else:
         logging.warning("Bad connection Returned code=%s", str(reason_code))
 
+
 def on_disconnect(client, userdata, disconnect_flags, reason_code, properties):
-    """"
+    """ "
     Handles actions on MQTT disconnect
     """
     logging.warning(
@@ -239,26 +296,27 @@ def on_disconnect(client, userdata, disconnect_flags, reason_code, properties):
         disconnect_flags,
         properties,
     )
-    client.connected_flag=False
-    client.disconnect_flag=True
+    client.connected_flag = False
+    client.disconnect_flag = True
+
 
 def _open_mqtt_connection(args):
     """
     Get MQTT client
     """
 
-    mqtt.Client.connected_flag = False #create flag in class
+    mqtt.Client.connected_flag = False  # create flag in class
     client = mqtt.Client(
         callback_api_version=mqtt.CallbackAPIVersion.VERSION2,
-        client_id='mtr2mqtt',
+        client_id="mtr2mqtt",
         userdata=None,
         protocol=mqtt.MQTTv311,
-        transport="tcp"
+        transport="tcp",
     )
     client.enable_logger()
     client.on_connect = on_connect
     client.on_disconnect = on_disconnect
-    mqtt_host = 'localhost'
+    mqtt_host = "localhost"
     mqtt_port = 1883
     if args.mqtt_host:
         mqtt_host = args.mqtt_host
@@ -270,7 +328,7 @@ def _open_mqtt_connection(args):
     print(f"Connecting to MQTT host: {mqtt_host}:{mqtt_port}")
     try:
         client.connect(mqtt_host, mqtt_port)
-        while not client.connected_flag: #wait in loop
+        while not client.connected_flag:  # wait in loop
             logging.debug("Waiting for MQTT connection")
             time.sleep(1)
     except (mqtt.socket.timeout, mqtt.socket.error) as e:
@@ -278,19 +336,21 @@ def _open_mqtt_connection(args):
         sys.exit(-1)
     return client
 
+
 def configure_logging(args):
     """
     Configure logging based on the provided arguments.
     """
-    log_format = '%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+    log_format = "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
     if args.debug:
         logging.basicConfig(level=logging.DEBUG, format=log_format)
         print("Debug logging enabled")
     elif args.quiet:
         logging.basicConfig(level=logging.WARNING)
     else:
-        logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(message)s')
+        logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(message)s")
         sys.tracebacklimit = 0
+
 
 def load_metadata(args):
     """
@@ -300,13 +360,61 @@ def load_metadata(args):
         return metadata.loadfile(args.metadata_file)
     return None
 
+
 def get_scl_commands(args):
     """
     Create SCL commands based on the provided arguments.
     """
-    scl_sn_command = scl.create_command('SN ?', args.scl_address)
-    scl_dbg_1_command = scl.create_command('DBG 1 ?', args.scl_address)
+    scl_sn_command = scl.create_command("SN ?", args.scl_address)
+    scl_dbg_1_command = scl.create_command("DBG 1 ?", args.scl_address)
     return scl_sn_command, scl_dbg_1_command
+
+
+def create_discovery_publisher(args):
+    """
+    Create a Home Assistant discovery publisher when enabled.
+    """
+    if not args.ha_discovery:
+        return None
+    return homeassistant.DiscoveryPublisher(
+        discovery_prefix=args.ha_discovery_prefix,
+        retain=args.ha_discovery_retain,
+        node_id=args.ha_discovery_node_id,
+    )
+
+
+def _publish_measurement(
+    mqtt_client,
+    receiver_serial_number,
+    measurement_json,
+    ha_discovery_publisher=None,
+):
+    """
+    Publish discovery first when enabled, then publish the measurement.
+    """
+    measurement = json.loads(measurement_json)
+    sensor_id = measurement["id"]
+
+    if ha_discovery_publisher:
+        ha_discovery_publisher.publish_if_needed(
+            mqtt_client,
+            receiver_serial_number,
+            measurement,
+        )
+
+    result, mid = mqtt_client.publish(
+        homeassistant.state_topic(receiver_serial_number, sensor_id),
+        payload=measurement_json,
+        qos=1,
+        retain=False,
+    )
+    logging.debug("publish result: %s, mid: %s", result, mid)
+    if result != 0:
+        logging.warning(
+            "Sending message: %s failed with result code: %s", measurement_json, result
+        )
+    return result, mid
+
 
 def main():
     """
@@ -338,36 +446,35 @@ def main():
     print(f"Receiver S/N: {receiver_serial_number}")
 
     mqtt_client = _open_mqtt_connection(args)
+    ha_discovery_publisher = create_discovery_publisher(args)
 
     try:
         while True:
-            response = _get_latest_from_ring_buffer(ser, scl_dbg_1_command, serial_config)
+            response = _get_latest_from_ring_buffer(
+                ser, scl_dbg_1_command, serial_config
+            )
             # Character # is returned when the buffer is empty
             if response != "#":
-                measurement_json = mtr.mtr_response_to_json(response, transmitters_metadata)
+                measurement_json = mtr.mtr_response_to_json(
+                    response, transmitters_metadata
+                )
                 if measurement_json:
                     logging.info(measurement_json)
-                    (result, mid) = mqtt_client.publish(
-                        f"measurements/{receiver_serial_number}/"
-                        f"{json.loads(measurement_json)['id']}",
-                        payload=measurement_json,
-                        qos=1,
-                        retain=False
+                    _publish_measurement(
+                        mqtt_client,
+                        receiver_serial_number,
+                        measurement_json,
+                        ha_discovery_publisher=ha_discovery_publisher,
                     )
-                    logging.debug("publish result: %s, mid: %s", result, mid)
-                    if result != 0:
-                        logging.warning(
-                            "Sending message: %s failed with result code: %s",
-                            measurement_json, result
-                        )
             else:
-                logging.debug('Ring buffer empty')
+                logging.debug("Ring buffer empty")
                 time.sleep(1)
     except KeyboardInterrupt:
         logging.info("Interrupted by user")
     finally:
         mqtt_client.loop_stop()
         mqtt_client.disconnect()
+
 
 if __name__ == "__main__":
     main()

--- a/mtr2mqtt/homeassistant.py
+++ b/mtr2mqtt/homeassistant.py
@@ -1,0 +1,290 @@
+"""
+Home Assistant MQTT Discovery helpers.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from importlib.metadata import PackageNotFoundError, version
+
+
+def sanitize_id(value):
+    """
+    Convert an arbitrary identifier into a Home Assistant safe object id fragment.
+    """
+    sanitized = re.sub(r"[^a-z0-9]+", "_", str(value).strip().lower())
+    return sanitized.strip("_") or "unknown"
+
+
+def state_topic(receiver_serial_number, sensor_id):
+    """
+    Build the measurement state topic.
+    """
+    return f"measurements/{receiver_serial_number}/{sensor_id}"
+
+
+def device_identifier(sensor_id):
+    """
+    Build a unique identifier shared by the Home Assistant device and entities.
+    """
+    return sanitize_id(sensor_id)
+
+
+def discovery_object_id(sensor_id):
+    """
+    Build the device discovery object id.
+    """
+    return device_identifier(sensor_id)
+
+
+def discovery_topic(
+    discovery_prefix,
+    _receiver_serial_number,
+    sensor_id,
+    node_id=None,
+):
+    """
+    Build the Home Assistant device discovery topic.
+    """
+    object_id = discovery_object_id(sensor_id)
+    if node_id:
+        return f"{discovery_prefix}/device/{sanitize_id(node_id)}/{object_id}/config"
+    return f"{discovery_prefix}/device/{object_id}/config"
+
+
+def _normalize_text(value):
+    if value is None:
+        return ""
+    return str(value).strip().casefold()
+
+
+def _infer_reading_device_class(measurement):
+    quantity = _normalize_text(measurement.get("quantity"))
+    unit = _normalize_text(measurement.get("unit"))
+
+    if "temperature" in quantity or unit in {"c", "°c"}:
+        return "temperature"
+    if "humidity" in quantity or unit in {"%", "percent", "relative humidity"}:
+        return "humidity"
+    if "pressure" in quantity or unit in {"pa", "hpa", "kpa", "bar", "mbar"}:
+        return "pressure"
+    return None
+
+
+def _infer_reading_state_class(measurement):
+    if measurement.get("reading") is not None:
+        return "measurement"
+    return None
+
+
+def infer_reading_entity_fields(measurement):
+    """
+    Infer a conservative set of Home Assistant sensor fields from metadata.
+    """
+    inferred = {}
+    if measurement.get("unit"):
+        inferred["unit_of_measurement"] = measurement["unit"]
+
+    device_class = _infer_reading_device_class(measurement)
+    if device_class:
+        inferred["device_class"] = device_class
+
+    state_class = _infer_reading_state_class(measurement)
+    if state_class:
+        inferred["state_class"] = state_class
+
+    return inferred
+
+
+def _reading_name(measurement):
+    ha_overrides = measurement.get("ha") or {}
+    if ha_overrides.get("name"):
+        return ha_overrides["name"]
+    return None
+
+
+def _device_name(measurement, sensor_id):
+    description = str(measurement.get("description") or "").strip()
+    location = str(measurement.get("location") or "").strip()
+    quantity = str(measurement.get("quantity") or "").strip().lower()
+
+    if location and description and quantity:
+        return f"{location} {description} {quantity}"
+    if description and location:
+        return f"{location} {description}"
+    if description:
+        return description
+    if location:
+        return f"{location} sensor {sensor_id}"
+    return f"Sensor {sensor_id}"
+
+
+def _origin():
+    try:
+        app_version = version("mtr2mqtt")
+    except PackageNotFoundError:
+        app_version = "unknown"
+    return {
+        "name": "mtr2mqtt",
+        "sw": app_version,
+        "url": "https://github.com/tvallas/mtr2mqtt",
+    }
+
+
+def _apply_reading_overrides(component, measurement):
+    ha_overrides = measurement.get("ha") or {}
+    for key in (
+        "device_class",
+        "state_class",
+        "suggested_display_precision",
+        "icon",
+        "unit_of_measurement",
+    ):
+        if key in ha_overrides:
+            component[key] = ha_overrides[key]
+
+    if "name" in ha_overrides:
+        component["name"] = ha_overrides["name"]
+
+
+def _default_reading_icon(measurement):
+    device_class = _infer_reading_device_class(measurement)
+    if device_class == "temperature":
+        return "mdi:home-thermometer"
+    if device_class == "humidity":
+        return "mdi:water-percent"
+    if device_class == "pressure":
+        return "mdi:gauge"
+    return None
+
+
+def _drop_none_values(data):
+    """
+    Remove keys with None values from a shallow dict.
+    """
+    return {key: value for key, value in data.items() if value is not None}
+
+
+def build_discovery_payload(receiver_serial_number, measurement):
+    """
+    Build a Home Assistant device discovery payload for a sensor measurement.
+    """
+    sensor_id = measurement["id"]
+    identifier = device_identifier(sensor_id)
+    base_object_id = discovery_object_id(sensor_id)
+    current_state_topic = state_topic(receiver_serial_number, sensor_id)
+
+    reading = _drop_none_values(
+        {
+            "p": "sensor",
+            "unique_id": f"{identifier}_reading",
+            "object_id": f"{base_object_id}_reading",
+            "value_template": "{{ value_json.reading }}",
+            "json_attributes_topic": current_state_topic,
+            "name": _reading_name(measurement),
+            "expire_after": 900,
+            "icon": _default_reading_icon(measurement),
+        }
+    )
+    reading.update(infer_reading_entity_fields(measurement))
+    _apply_reading_overrides(reading, measurement)
+
+    battery = {
+        "p": "sensor",
+        "unique_id": f"{identifier}_battery",
+        "object_id": f"{base_object_id}_battery",
+        "name": "Battery",
+        "value_template": "{{ value_json.battery }}",
+        "device_class": "voltage",
+        "state_class": "measurement",
+        "unit_of_measurement": "V",
+        "entity_category": "diagnostic",
+    }
+
+    rsl = {
+        "p": "sensor",
+        "unique_id": f"{identifier}_rsl",
+        "object_id": f"{base_object_id}_rsl",
+        "name": "Signal",
+        "value_template": "{{ value_json.rsl }}",
+        "state_class": "measurement",
+        "unit_of_measurement": "dBm",
+        "entity_category": "diagnostic",
+        "icon": "mdi:signal",
+    }
+
+    payload = {
+        "dev": {
+            "ids": [identifier],
+            "name": _device_name(measurement, sensor_id),
+            "mf": "Nokeval",
+            "mdl": measurement.get("type", "MTR transmitter"),
+            "sn": str(sensor_id),
+            "suggested_area": measurement.get("location"),
+        },
+        "o": _origin(),
+        "state_topic": current_state_topic,
+        "qos": 1,
+        "cmps": {
+            "reading": reading,
+            "battery": battery,
+            "rsl": rsl,
+        },
+    }
+    return json.dumps(payload)
+
+
+class DiscoveryPublisher:
+    """
+    Publish Home Assistant discovery payloads once per receiver and sensor pair.
+    """
+
+    def __init__(self, discovery_prefix, retain=True, node_id=None):
+        self.discovery_prefix = discovery_prefix
+        self.retain = retain
+        self.node_id = node_id
+        self._published = set()
+
+    def has_published(self, receiver_serial_number, sensor_id):
+        """
+        Return whether discovery is already published for this receiver/sensor.
+        """
+        return (str(receiver_serial_number), str(sensor_id)) in self._published
+
+    def publish_if_needed(self, mqtt_client, receiver_serial_number, measurement):
+        """
+        Publish discovery once when the first real measurement arrives.
+        """
+        sensor_id = str(measurement["id"])
+        cache_key = (str(receiver_serial_number), sensor_id)
+        if cache_key in self._published:
+            return True
+
+        topic = discovery_topic(
+            self.discovery_prefix,
+            receiver_serial_number,
+            sensor_id,
+            node_id=self.node_id,
+        )
+        payload = build_discovery_payload(receiver_serial_number, measurement)
+        result, mid = mqtt_client.publish(
+            topic,
+            payload=payload,
+            qos=1,
+            retain=self.retain,
+        )
+        logging.debug("HA discovery publish result: %s, mid: %s", result, mid)
+        if result == 0:
+            self._published.add(cache_key)
+            return True
+
+        logging.warning(
+            "Sending Home Assistant discovery for receiver %s sensor %s failed "
+            "with result code: %s",
+            receiver_serial_number,
+            sensor_id,
+            result,
+        )
+        return False

--- a/sample_metadata.yml
+++ b/sample_metadata.yml
@@ -4,8 +4,19 @@
   description: 'Ambient air temperature'
   unit: '°C'
   quantity: 'Temperature'
+  ha:
+    name: 'Ambient'
+    device_class: 'temperature'
+    state_class: 'measurement'
+    suggested_display_precision: 1
+    icon: 'mdi:thermometer'
 - id: 54321
   location: 'Living room'
   unit: '%'
   description: 'Ambient air humidity'
   quantity: 'Humidity'
+- id: 60001
+  location: 'Utility room'
+  description: 'Line pressure'
+  unit: 'hPa'
+  quantity: 'Pressure'

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,6 +1,7 @@
 """
 Tests for cli module
 """
+
 from types import SimpleNamespace
 
 import pytest
@@ -38,6 +39,10 @@ def test_parser_defaults_without_arguments(monkeypatch):
     monkeypatch.delenv("MTR2MQTT_MQTT_HOST", raising=False)
     monkeypatch.delenv("MTR2MQTT_MQTT_PORT", raising=False)
     monkeypatch.delenv("MTR2MQTT_METADATA_FILE", raising=False)
+    monkeypatch.delenv("MTR2MQTT_HA_DISCOVERY", raising=False)
+    monkeypatch.delenv("MTR2MQTT_HA_DISCOVERY_PREFIX", raising=False)
+    monkeypatch.delenv("MTR2MQTT_HA_DISCOVERY_RETAIN", raising=False)
+    monkeypatch.delenv("MTR2MQTT_HA_DISCOVERY_NODE_ID", raising=False)
     monkeypatch.delenv("MTR2MQTT_DEBUG", raising=False)
     monkeypatch.delenv("MTR2MQTT_QUIET", raising=False)
 
@@ -51,6 +56,10 @@ def test_parser_defaults_without_arguments(monkeypatch):
     assert args.mqtt_host is None
     assert args.mqtt_port == 1883
     assert args.metadata_file is None
+    assert args.ha_discovery is False
+    assert args.ha_discovery_prefix == "homeassistant"
+    assert args.ha_discovery_retain is True
+    assert args.ha_discovery_node_id is None
     assert args.debug is False
     assert args.quiet is False
     assert args.version is False
@@ -67,6 +76,10 @@ def test_parser_reads_environment_defaults(monkeypatch):
     monkeypatch.setenv("MTR2MQTT_MQTT_HOST", "mqtt.example")
     monkeypatch.setenv("MTR2MQTT_MQTT_PORT", "1884")
     monkeypatch.setenv("MTR2MQTT_METADATA_FILE", "tests/metadata.yml")
+    monkeypatch.setenv("MTR2MQTT_HA_DISCOVERY", "true")
+    monkeypatch.setenv("MTR2MQTT_HA_DISCOVERY_PREFIX", "ha")
+    monkeypatch.setenv("MTR2MQTT_HA_DISCOVERY_RETAIN", "false")
+    monkeypatch.setenv("MTR2MQTT_HA_DISCOVERY_NODE_ID", "bridge-1")
     monkeypatch.setenv("MTR2MQTT_DEBUG", "true")
     monkeypatch.delenv("MTR2MQTT_QUIET", raising=False)
 
@@ -80,6 +93,10 @@ def test_parser_reads_environment_defaults(monkeypatch):
     assert args.mqtt_host == "mqtt.example"
     assert args.mqtt_port == 1884
     assert args.metadata_file == "tests/metadata.yml"
+    assert args.ha_discovery is True
+    assert args.ha_discovery_prefix == "ha"
+    assert args.ha_discovery_retain is False
+    assert args.ha_discovery_node_id == "bridge-1"
     assert args.debug is True
     assert args.quiet is False
 
@@ -108,6 +125,28 @@ def test_parser_quiet_flag_enables_quiet():
     assert args.version is False
 
 
+def test_parser_home_assistant_flags():
+    """
+    The parser accepts Home Assistant discovery options.
+    """
+    parser = cli.create_parser()
+    args = parser.parse_args(
+        [
+            "--ha-discovery",
+            "--ha-discovery-prefix",
+            "ha",
+            "--no-ha-discovery-retain",
+            "--ha-discovery-node-id",
+            "bridge-1",
+        ]
+    )
+
+    assert args.ha_discovery is True
+    assert args.ha_discovery_prefix == "ha"
+    assert args.ha_discovery_retain is False
+    assert args.ha_discovery_node_id == "bridge-1"
+
+
 def test_parser_rejects_debug_and_quiet_together():
     """
     Mutually exclusive debug and quiet flags cannot be used together.
@@ -123,14 +162,22 @@ def test_parser_parses_common_options():
     The parser accepts common numeric and file options.
     """
     parser = cli.create_parser()
-    args = parser.parse_args([
-        "--mqtt-host", "localhost",
-        "--mqtt-port", "1885",
-        "--baudrate", "115200",
-        "--serial-timeout", "2",
-        "--scl-address", "0",
-        "--metadata-file", "tests/metadata.yml",
-    ])
+    args = parser.parse_args(
+        [
+            "--mqtt-host",
+            "localhost",
+            "--mqtt-port",
+            "1885",
+            "--baudrate",
+            "115200",
+            "--serial-timeout",
+            "2",
+            "--scl-address",
+            "0",
+            "--metadata-file",
+            "tests/metadata.yml",
+        ]
+    )
 
     assert args.mqtt_host == "localhost"
     assert args.mqtt_port == "1885"
@@ -192,3 +239,106 @@ def test_open_mqtt_connection_uses_callback_api_v2(monkeypatch):
     assert captured["loop_start"] is True
     assert client.on_connect is cli.on_connect
     assert client.on_disconnect is cli.on_disconnect
+
+
+def test_create_discovery_publisher_returns_none_when_disabled():
+    """
+    Discovery publisher creation is skipped unless discovery is enabled.
+    """
+    args = SimpleNamespace(
+        ha_discovery=False,
+        ha_discovery_prefix="homeassistant",
+        ha_discovery_retain=True,
+        ha_discovery_node_id=None,
+    )
+
+    assert cli.create_discovery_publisher(args) is None
+
+
+def test_create_discovery_publisher_uses_cli_configuration():
+    """
+    Discovery publisher creation preserves the configured prefix, retain, and node id.
+    """
+    args = SimpleNamespace(
+        ha_discovery=True,
+        ha_discovery_prefix="ha",
+        ha_discovery_retain=False,
+        ha_discovery_node_id="bridge-1",
+    )
+
+    publisher = cli.create_discovery_publisher(args)
+
+    assert publisher.discovery_prefix == "ha"
+    assert publisher.retain is False
+    assert publisher.node_id == "bridge-1"
+
+
+def test_publish_measurement_publishes_discovery_first():
+    """
+    Measurement publishing keeps the normal state topic and publishes discovery first.
+    """
+
+    class FakeClient:
+        def __init__(self):
+            self.calls = []
+
+        def publish(self, topic, **kwargs):
+            self.calls.append((topic, kwargs))
+            return (0, len(self.calls))
+
+    client = FakeClient()
+    publisher = cli.homeassistant.DiscoveryPublisher("homeassistant", retain=True)
+    measurement_json = (
+        '{"id":"15006","type":"FT10","reading":22.9,"battery":2.6,"rsl":-69}'
+    )
+
+    result, mid = cli._publish_measurement(
+        client,
+        "RTR970123",
+        measurement_json,
+        ha_discovery_publisher=publisher,
+    )
+
+    assert result == 0
+    assert mid == 2
+    assert client.calls[0][0] == "homeassistant/device/15006/config"
+    assert client.calls[0][1]["qos"] == 1
+    assert client.calls[0][1]["retain"] is True
+    assert client.calls[1][0] == "measurements/RTR970123/15006"
+    assert client.calls[1][1]["payload"] == measurement_json
+    assert client.calls[1][1]["retain"] is False
+
+
+def test_publish_measurement_without_discovery_keeps_normal_publish_behavior():
+    """
+    Measurement publishing still works unchanged when discovery is disabled.
+    """
+
+    class FakeClient:
+        def __init__(self):
+            self.calls = []
+
+        def publish(self, topic, **kwargs):
+            self.calls.append((topic, kwargs))
+            return (0, 1)
+
+    client = FakeClient()
+    measurement_json = (
+        '{"id":"15006","type":"FT10","reading":22.9,"battery":2.6,"rsl":-69}'
+    )
+
+    result, mid = cli._publish_measurement(
+        client,
+        "RTR970123",
+        measurement_json,
+        ha_discovery_publisher=None,
+    )
+
+    assert result == 0
+    assert mid == 1
+    assert client.calls == [
+        (
+            "measurements/RTR970123/15006",
+            {"payload": measurement_json, "qos": 1, "retain": False},
+        )
+    ]

--- a/tests/test_homeassistant.py
+++ b/tests/test_homeassistant.py
@@ -1,0 +1,286 @@
+"""
+Tests for Home Assistant MQTT discovery helpers.
+"""
+
+import json
+
+from context import mtr2mqtt
+from mtr2mqtt import homeassistant
+
+
+def test_discovery_topic_without_node_id():
+    """
+    Discovery topics use the device discovery path without a node id by default.
+    """
+    assert (
+        homeassistant.discovery_topic("homeassistant", "RTR970123", "15006")
+        == "homeassistant/device/15006/config"
+    )
+
+
+def test_discovery_topic_with_node_id():
+    """
+    Discovery topics include the optional node id namespace when configured.
+    """
+    assert (
+        homeassistant.discovery_topic(
+            "ha",
+            "RTR970123",
+            "15006",
+            node_id="MTR Bridge 1",
+        )
+        == "ha/device/mtr_bridge_1/15006/config"
+    )
+
+
+def test_build_discovery_payload_contains_expected_components():
+    """
+    Device discovery payloads include reading, battery, and rsl components.
+    """
+    measurement = {
+        "id": "15006",
+        "type": "FT10",
+        "reading": 22.9,
+        "battery": 2.6,
+        "rsl": -69,
+        "location": "Living room",
+        "description": "Ambient air temperature",
+        "unit": "°C",
+        "quantity": "Temperature",
+    }
+
+    payload = json.loads(
+        homeassistant.build_discovery_payload("RTR970123", measurement)
+    )
+
+    assert payload["state_topic"] == "measurements/RTR970123/15006"
+    assert payload["dev"]["ids"] == ["15006"]
+    assert payload["dev"]["name"] == "Living room Ambient air temperature temperature"
+    assert payload["dev"]["suggested_area"] == "Living room"
+    assert set(payload["cmps"]) == {"reading", "battery", "rsl"}
+    assert payload["cmps"]["reading"]["p"] == "sensor"
+    assert payload["cmps"]["reading"]["unique_id"] == "15006_reading"
+    assert payload["cmps"]["reading"]["object_id"] == "15006_reading"
+    assert payload["cmps"]["reading"]["value_template"] == "{{ value_json.reading }}"
+    assert (
+        payload["cmps"]["reading"]["json_attributes_topic"]
+        == "measurements/RTR970123/15006"
+    )
+    assert "name" not in payload["cmps"]["reading"]
+    assert payload["cmps"]["reading"]["expire_after"] == 900
+    assert payload["cmps"]["reading"]["icon"] == "mdi:home-thermometer"
+    assert payload["cmps"]["battery"]["name"] == "Battery"
+    assert payload["cmps"]["battery"]["value_template"] == "{{ value_json.battery }}"
+    assert payload["cmps"]["rsl"]["name"] == "Signal"
+    assert payload["cmps"]["rsl"]["value_template"] == "{{ value_json.rsl }}"
+
+
+def test_build_discovery_payload_inferrs_temperature_fields():
+    """
+    Temperature metadata is mapped conservatively to Home Assistant fields.
+    """
+    measurement = {
+        "id": "15006",
+        "type": "FT10",
+        "reading": 22.9,
+        "battery": 2.6,
+        "rsl": -69,
+        "unit": "°C",
+        "quantity": "Temperature",
+    }
+
+    payload = json.loads(
+        homeassistant.build_discovery_payload("RTR970123", measurement)
+    )
+
+    assert payload["cmps"]["reading"]["device_class"] == "temperature"
+    assert payload["cmps"]["reading"]["state_class"] == "measurement"
+    assert payload["cmps"]["reading"]["unit_of_measurement"] == "°C"
+    assert payload["cmps"]["reading"]["icon"] == "mdi:home-thermometer"
+
+
+def test_build_discovery_payload_inferrs_humidity_from_quantity():
+    """
+    Humidity-like quantity metadata maps to the humidity device class.
+    """
+    measurement = {
+        "id": "15007",
+        "type": "FT10",
+        "reading": 45.0,
+        "battery": 2.7,
+        "rsl": -70,
+        "unit": "%",
+        "quantity": "Relative humidity",
+    }
+
+    payload = json.loads(
+        homeassistant.build_discovery_payload("RTR970123", measurement)
+    )
+
+    assert payload["cmps"]["reading"]["device_class"] == "humidity"
+    assert payload["cmps"]["reading"]["icon"] == "mdi:water-percent"
+
+
+def test_build_discovery_payload_applies_optional_ha_overrides():
+    """
+    Optional Home Assistant metadata overrides take precedence for the main reading.
+    """
+    measurement = {
+        "id": "12345",
+        "type": "FT10",
+        "reading": 21.2,
+        "battery": 2.8,
+        "rsl": -60,
+        "location": "Living room",
+        "description": "Ambient air temperature",
+        "unit": "°C",
+        "quantity": "Temperature",
+        "ha": {
+            "name": "Ambient",
+            "device_class": "temperature",
+            "state_class": "measurement",
+            "suggested_display_precision": 1,
+            "icon": "mdi:thermometer",
+        },
+    }
+
+    payload = json.loads(
+        homeassistant.build_discovery_payload("RTR970123", measurement)
+    )
+
+    assert payload["cmps"]["reading"]["name"] == "Ambient"
+    assert payload["cmps"]["reading"]["device_class"] == "temperature"
+    assert payload["cmps"]["reading"]["state_class"] == "measurement"
+    assert payload["cmps"]["reading"]["suggested_display_precision"] == 1
+    assert payload["cmps"]["reading"]["icon"] == "mdi:thermometer"
+
+
+def test_build_discovery_payload_uses_name_when_metadata_override_exists():
+    """
+    Reading name is included only when metadata or HA overrides provide it.
+    """
+    measurement = {
+        "id": "12345",
+        "type": "FT10",
+        "reading": 21.2,
+        "battery": 2.8,
+        "rsl": -60,
+        "ha": {
+            "name": "Ambient",
+        },
+    }
+
+    payload = json.loads(
+        homeassistant.build_discovery_payload("RTR970123", measurement)
+    )
+
+    assert payload["cmps"]["reading"]["name"] == "Ambient"
+
+
+def test_build_discovery_payload_exposes_metadata_as_reading_attributes():
+    """
+    The primary reading entity exposes the measurement JSON as HA attributes.
+    """
+    measurement = {
+        "id": "12345",
+        "type": "FT10",
+        "reading": 21.2,
+        "battery": 2.8,
+        "rsl": -60,
+        "location": "Living room",
+        "description": "Ambient air",
+        "quantity": "Temperature",
+        "zone": "Indoor",
+    }
+
+    payload = json.loads(
+        homeassistant.build_discovery_payload("RTR970123", measurement)
+    )
+
+    assert (
+        payload["cmps"]["reading"]["json_attributes_topic"]
+        == "measurements/RTR970123/12345"
+    )
+
+
+def test_build_discovery_payload_uses_specific_device_name_for_fridge_like_sensor():
+    """
+    Device names include location, description, and quantity to mirror legacy HA names.
+    """
+    measurement = {
+        "id": "27054",
+        "type": "FT10",
+        "reading": 4.2,
+        "battery": 2.8,
+        "rsl": -60,
+        "location": "Kitchen",
+        "description": "Fridge",
+        "quantity": "Temperature",
+    }
+
+    payload = json.loads(
+        homeassistant.build_discovery_payload("RTR970123", measurement)
+    )
+
+    assert payload["dev"]["name"] == "Kitchen Fridge temperature"
+
+
+def test_discovery_publisher_only_marks_successful_publishes():
+    """
+    Discovery publish tracking updates only after a successful MQTT publish.
+    """
+
+    class FakeClient:
+        def __init__(self):
+            self.calls = []
+            self.results = [(1, 10), (0, 11)]
+
+        def publish(self, *args, **kwargs):
+            self.calls.append((args, kwargs))
+            return self.results.pop(0)
+
+    publisher = homeassistant.DiscoveryPublisher("homeassistant", retain=True)
+    client = FakeClient()
+    measurement = {
+        "id": "15006",
+        "type": "FT10",
+        "reading": 22.9,
+        "battery": 2.6,
+        "rsl": -69,
+    }
+
+    assert publisher.publish_if_needed(client, "RTR970123", measurement) is False
+    assert publisher.has_published("RTR970123", "15006") is False
+
+    assert publisher.publish_if_needed(client, "RTR970123", measurement) is True
+    assert publisher.has_published("RTR970123", "15006") is True
+    assert len(client.calls) == 2
+
+
+def test_discovery_publisher_skips_repeated_publish_after_success():
+    """
+    Discovery is published only once per receiver and sensor during the process lifetime.
+    """
+
+    class FakeClient:
+        def __init__(self):
+            self.calls = []
+
+        def publish(self, *args, **kwargs):
+            self.calls.append((args, kwargs))
+            return (0, 1)
+
+    publisher = homeassistant.DiscoveryPublisher("homeassistant", retain=False)
+    client = FakeClient()
+    measurement = {
+        "id": "15006",
+        "type": "FT10",
+        "reading": 22.9,
+        "battery": 2.6,
+        "rsl": -69,
+    }
+
+    assert publisher.publish_if_needed(client, "RTR970123", measurement) is True
+    assert publisher.publish_if_needed(client, "RTR970123", measurement) is True
+    assert len(client.calls) == 1
+    assert client.calls[0][1]["retain"] is False


### PR DESCRIPTION
## Summary
This PR adds optional Home Assistant MQTT Discovery support to `mtr2mqtt` so detected transmitters appear automatically in Home Assistant without changing the existing measurement topic structure.

## Problem
Today `mtr2mqtt` publishes useful measurement JSON, but Home Assistant users still need to model each sensor manually even though the data and metadata are already well suited for MQTT auto-discovery.

## Implementation approach
- add a dedicated `mtr2mqtt.homeassistant` helper module for object id sanitizing, discovery topic generation, payload generation, metadata mapping, conservative inference, and publish-once tracking
- keep the existing state topic unchanged at `measurements/<receiver_serial_number>/<sensor_id>`
- wire discovery publishing into the main measurement publish path so discovery is sent when the first real measurement is seen for a receiver and sensor pair
- publish discovery with QoS 1 and configurable retain behavior, only marking it as published after a successful MQTT publish

## Why device discovery
This uses Home Assistant MQTT device-based discovery instead of per-entity legacy discovery so each physical transmitter is represented as one Home Assistant device with multiple related entities.

## Entities created
Each detected transmitter creates one Home Assistant device with:
- `reading` as the primary sensor entity
- `battery` as a diagnostic voltage sensor
- `rsl` as a diagnostic signal sensor

The receiver serial number is included in identifiers and unique ids to avoid collisions across receivers.

## New configuration
CLI flags and matching environment variables:
- `--ha-discovery` / `MTR2MQTT_HA_DISCOVERY`
- `--ha-discovery-prefix` / `MTR2MQTT_HA_DISCOVERY_PREFIX`
- `--ha-discovery-retain` / `MTR2MQTT_HA_DISCOVERY_RETAIN`
- `--ha-discovery-node-id` / `MTR2MQTT_HA_DISCOVERY_NODE_ID`

The optional metadata `ha:` block can override the primary reading entity with fields such as `name`, `device_class`, `state_class`, `suggested_display_precision`, and `icon`.

## Tests added
- CLI parsing for the new Home Assistant discovery flags
- environment variable handling for the new Home Assistant options
- discovery topic generation with and without node ids
- device discovery payload generation and `cmps` contents for `reading`, `battery`, and `rsl`
- state topic references in discovery payloads
- conservative device class inference from metadata
- optional `ha:` override behavior
- publish-once tracking for discovery
- measurement publish behavior with and without discovery enabled

## Validation
- `uv run pytest -v`
- `uv run pylint $(find mtr2mqtt -name "*.py" -type f)`

## Compatibility
Existing measurement topics remain unchanged and measurement payloads continue to be published as non-retained MQTT messages.