### PR TITLE
[codex] Recover from serial device disconnects

### DIFF
--- a/mtr2mqtt/cli.py
+++ b/mtr2mqtt/cli.py
@@ -24,6 +24,8 @@ from mtr2mqtt import mtr
 from mtr2mqtt import metadata
 from mtr2mqtt import homeassistant
 
+SERIAL_PORT_GREP = "RTR|FTR|DCS|DPR"
+
 
 def _env_flag(name, default=False):
     """
@@ -186,11 +188,6 @@ def _open_receiver_port(args):
     """
     Open serial port connection
     """
-
-    # Trying to find MTR compatible receiver
-    # Filtering ports with Nokeval manufactured models that MTR receivers might use
-    serial_ports = list(list_ports.grep("RTR|FTR|DCS|DPR"))
-
     ser = serial.Serial()
 
     # Check if serial port was given as argument
@@ -215,6 +212,9 @@ def _open_receiver_port(args):
             logging.exception("Unable to open serial port")
             sys.exit(-1)
     else:
+        # Trying to find MTR compatible receiver
+        # Filtering ports with Nokeval manufactured models that MTR receivers might use
+        serial_ports = list(list_ports.grep(SERIAL_PORT_GREP))
         for port in serial_ports:
             try:
                 ser = serial.Serial(
@@ -229,15 +229,63 @@ def _open_receiver_port(args):
                     device_type = scl.get_receiver_type(ser, args.scl_address)
                     if device_type:
                         print(f"Connected device type: {device_type}")
+                        return ser
+                    ser.close()
             except serial.serialutil.SerialException:
                 pass
     return ser
 
 
-def _get_latest_from_ring_buffer(ser, scl_dbg_1_command, serial_config):
+def _recover_serial_connection(ser, args, serial_config):
+    """
+    Try to restore serial connectivity after a runtime I/O failure.
+    """
+    current_port = ser.port
+
+    try:
+        ser.close()
+    except (OSError, serial.serialutil.SerialException):
+        logging.debug("Closing failed serial port %s raised an exception", current_port)
+
+    if current_port:
+        try:
+            logging.warning("Trying to reopen serial port: %s", current_port)
+            reopened_ser = serial.Serial()
+            reopened_ser.port = current_port
+            reopened_ser.apply_settings(serial_config)
+            reopened_ser.open()
+            device_type = scl.get_receiver_type(reopened_ser, args.scl_address)
+            if device_type:
+                logging.info("Recovered serial connection on %s", current_port)
+                print(f"Connected device type: {device_type}")
+                return reopened_ser
+            logging.warning(
+                "Reopened serial port %s but did not detect a compatible receiver",
+                current_port,
+            )
+            reopened_ser.close()
+        except serial.serialutil.SerialException:
+            logging.exception("Serial exception: opening serial port failed")
+        except FileNotFoundError:
+            logging.exception("File not found: opening serial port failed")
+        except OSError:
+            logging.exception("OS Error: opening serial port failed")
+
+    if not args.serial_port:
+        logging.warning("Trying to rediscover receiver port")
+        ser = _open_receiver_port(args)
+        if ser.is_open:
+            logging.info("Recovered serial connection on rediscovered port %s", ser.port)
+            return ser
+
+    return ser
+
+
+def _get_latest_from_ring_buffer(ser, scl_dbg_1_command, serial_config, args):
     """ "
     Get latest packet from MTR receiver ring buffer
     """
+    parsed_response = None
     try:
         ser.write(scl_dbg_1_command)
         logging.debug("Wrote message: %s to: to %s", scl_dbg_1_command, ser.name)
@@ -248,24 +296,11 @@ def _get_latest_from_ring_buffer(ser, scl_dbg_1_command, serial_config):
             "response: %s, response checksum: %s", response, response_checksum
         )
         logging.debug("parsed SCL response: %s", parsed_response)
-    except OSError:
-        logging.exception("OS Error: Reading to serial port failed")
-        ser.close()
+    except (OSError, serial.serialutil.SerialException):
+        logging.exception("Reading from serial port failed")
         time.sleep(1)
-        try:
-            logging.warning("Trying to reopen serial port")
-            ser.apply_settings(serial_config)
-            ser.open()
-        except serial.serialutil.SerialException:
-            logging.exception("Serial exception: opening serial port failed")
-            time.sleep(1)
-        except FileNotFoundError:
-            logging.exception("File not found: opening serial port failed")
-            time.sleep(1)
-        except OSError:
-            logging.exception("OS Error: opening serial port failed")
-            time.sleep(1)
-    return parsed_response
+        ser = _recover_serial_connection(ser, args, serial_config)
+    return parsed_response, ser
 
 
 def on_connect(client, userdata, flags, reason_code, properties):
@@ -314,6 +349,7 @@ def _open_mqtt_connection(args):
         transport="tcp",
     )
     client.enable_logger()
+    client.reconnect_delay_set(min_delay=1, max_delay=30)
     client.on_connect = on_connect
     client.on_disconnect = on_disconnect
     mqtt_host = "localhost"
@@ -395,6 +431,14 @@ def _publish_measurement(
     measurement = json.loads(measurement_json)
     sensor_id = measurement["id"]
 
+    if not getattr(mqtt_client, "connected_flag", True):
+        logging.warning(
+            "Skipping publish for receiver %s sensor %s because MQTT is disconnected",
+            receiver_serial_number,
+            sensor_id,
+        )
+        return mqtt.MQTT_ERR_NO_CONN, None
+
     if ha_discovery_publisher:
         ha_discovery_publisher.publish_if_needed(
             mqtt_client,
@@ -450,9 +494,13 @@ def main():
 
     try:
         while True:
-            response = _get_latest_from_ring_buffer(
-                ser, scl_dbg_1_command, serial_config
+            response, ser = _get_latest_from_ring_buffer(
+                ser, scl_dbg_1_command, serial_config, args
             )
+            if response is None:
+                logging.debug("No readable response from receiver")
+                time.sleep(1)
+                continue
             # Character # is returned when the buffer is empty
             if response != "#":
                 measurement_json = mtr.mtr_response_to_json(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -211,6 +211,9 @@ def test_open_mqtt_connection_uses_callback_api_v2(monkeypatch):
         def enable_logger(self):
             captured["enable_logger"] = True
 
+        def reconnect_delay_set(self, min_delay, max_delay):
+            captured["reconnect_delay_set"] = (min_delay, max_delay)
+
         def loop_start(self):
             captured["loop_start"] = True
 
@@ -235,10 +238,105 @@ def test_open_mqtt_connection_uses_callback_api_v2(monkeypatch):
     assert captured["kwargs"]["protocol"] == cli.mqtt.MQTTv311
     assert captured["kwargs"]["transport"] == "tcp"
     assert captured["connect"] == ("mqtt.example", 1884)
+    assert captured["reconnect_delay_set"] == (1, 30)
     assert captured["enable_logger"] is True
     assert captured["loop_start"] is True
     assert client.on_connect is cli.on_connect
     assert client.on_disconnect is cli.on_disconnect
+
+
+def test_get_latest_from_ring_buffer_returns_none_and_recovers_after_io_error(
+    monkeypatch,
+):
+    """
+    Serial I/O errors do not crash the loop and instead trigger recovery.
+    """
+
+    class BrokenSerial:
+        port = "/dev/cu.usbserial-NA118636"
+        name = port
+
+        def write(self, _command):
+            raise OSError("Device not configured")
+
+    replacement_serial = object()
+    recovery_calls = {}
+
+    def fake_recover(ser, args, serial_config):
+        recovery_calls["args"] = (ser, args, serial_config)
+        return replacement_serial
+
+    monkeypatch.setattr(cli, "_recover_serial_connection", fake_recover)
+    monkeypatch.setattr(cli.time, "sleep", lambda _: None)
+
+    args = SimpleNamespace(serial_port="/dev/cu.usbserial-NA118636", scl_address=126)
+
+    response, recovered_serial = cli._get_latest_from_ring_buffer(
+        BrokenSerial(),
+        b"DBG 1 ?",
+        {"baudrate": 9600},
+        args,
+    )
+
+    assert response is None
+    assert recovered_serial is replacement_serial
+    assert recovery_calls["args"][1] is args
+    assert recovery_calls["args"][2] == {"baudrate": 9600}
+
+
+def test_recover_serial_connection_rediscovery_finds_replugged_receiver(monkeypatch):
+    """
+    Autodetect mode rescans for a receiver when reopening the old port fails.
+    """
+
+    class ExistingSerial:
+        def __init__(self):
+            self.port = "/dev/cu.usbserial-old"
+            self.closed = False
+
+        def close(self):
+            self.closed = True
+
+    class ReopenAttempt:
+        def __init__(self):
+            self.port = None
+
+        def apply_settings(self, _settings):
+            pass
+
+        def open(self):
+            raise FileNotFoundError("device disappeared")
+
+    rediscovered_serial = SimpleNamespace(is_open=True, port="/dev/cu.usbserial-new")
+    current_serial = ExistingSerial()
+
+    monkeypatch.setattr(cli.serial, "Serial", ReopenAttempt)
+    monkeypatch.setattr(cli, "_open_receiver_port", lambda _args: rediscovered_serial)
+
+    recovered = cli._recover_serial_connection(
+        current_serial,
+        SimpleNamespace(serial_port=None, scl_address=126),
+        {"baudrate": 9600},
+    )
+
+    assert current_serial.closed is True
+    assert recovered is rediscovered_serial
+
+
+def test_publish_measurement_skips_while_mqtt_is_disconnected():
+    """
+    Measurements are skipped cleanly when MQTT is temporarily disconnected.
+    """
+
+    client = SimpleNamespace(connected_flag=False)
+    result, mid = cli._publish_measurement(
+        client,
+        "RTR970123",
+        '{"id": "15006", "reading": 22.9}',
+    )
+
+    assert result == cli.mqtt.MQTT_ERR_NO_CONN
+    assert mid is None
 
 
 def test_create_discovery_publisher_returns_none_when_disabled():


### PR DESCRIPTION
## Summary
- prevent the serial read loop from crashing after a device disconnect
- try to reopen the previous serial port and rediscover the receiver in autodetect mode
- skip MQTT publishes while disconnected and cover the failure paths with regression tests

## Root Cause
The runtime serial error path returned `parsed_response` even when it was never assigned, which caused an `UnboundLocalError` after USB disconnects.

## Validation
- uv run pytest