### PR TITLE
fix: handle unexpected metadata shapes

### DIFF
--- a/mtr2mqtt/metadata.py
+++ b/mtr2mqtt/metadata.py
@@ -32,10 +32,22 @@ def get_data(transmitter_id, all_transmitters):
     all_transmitters = json.loads(all_transmitters)
     logging.debug("All transmitters metadata: %s", all_transmitters)
     logging.debug("Transmitter id: %s", transmitter_id)
+    if not isinstance(all_transmitters, list):
+        logging.warning(
+            "Metadata must be a list of transmitters, got %s",
+            type(all_transmitters).__name__,
+        )
+        return None
     info = None
     for transmitter in all_transmitters:
+        if not isinstance(transmitter, dict):
+            logging.debug(
+                "Skipping metadata entry with unexpected type: %s",
+                type(transmitter).__name__,
+            )
+            continue
         logging.debug("Iterated transmitter: %s", transmitter)
-        if transmitter['id'] == int(transmitter_id):
+        if transmitter.get('id') == int(transmitter_id):
             info = transmitter.copy()
             info.pop('id', None)
             break

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -59,6 +59,37 @@ def test_metadata_get_data_with_empty_metadata_list():
     assert metadata.get_data(2345, json.dumps([])) is None
 
 
+def test_metadata_get_data_with_null_metadata():
+    """
+    metadata.get_data returns None when metadata input is JSON null.
+    """
+    assert metadata.get_data(2345, "null") is None
+
+
+def test_metadata_get_data_with_mapping_metadata():
+    """
+    metadata.get_data returns None when metadata input is a JSON object.
+    """
+    assert metadata.get_data(2345, json.dumps({
+        "id": 2345,
+        "location": "Room 2",
+    })) is None
+
+
+def test_metadata_get_data_skips_non_mapping_entries():
+    """
+    metadata.get_data ignores malformed list entries and still finds valid ones.
+    """
+    assert metadata.get_data(2345, json.dumps([
+        "invalid",
+        {
+            "id": 2345,
+            "location": "Room 2",
+            "unit": "%",
+        },
+    ])) == METADATA_TEST_TRANSMITTER_OUTPUT
+
+
 def test_metadata_loadfile_with_empty_file(tmp_path):
     """
     metadata.loadfile returns JSON null for an empty YAML file.


### PR DESCRIPTION
## Summary
- harden metadata lookup so valid YAML shapes like `null` or a mapping do not crash runtime processing
- skip malformed metadata entries while still returning matching transmitter metadata from valid list items
- add regression coverage for null, mapping, and mixed-entry metadata inputs

## Why
`metadata.loadfile()` can return JSON derived from any valid YAML content, but `metadata.get_data()` previously assumed the parsed value was always a list of dictionaries. That meant valid but unexpected metadata shapes could raise at runtime instead of failing safely.

## Validation
- `uv run pytest tests/test_metadata.py`
- `uv run pytest`
