### PR TITLE
fix: harden startup, parser, and MQTT error handling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ test:
 	uv run pytest -v
 
 lint:
-	uv run pylint $(find mtr2mqtt -name "*.py" -type f)
+	uv run pylint $$(find mtr2mqtt -name "*.py" -type f)
 
 build:
 	uv build

--- a/mtr2mqtt/cli.py
+++ b/mtr2mqtt/cli.py
@@ -17,6 +17,12 @@ from mtr2mqtt.runtime import BridgeError
 from mtr2mqtt.runtime import MtrBridge
 
 
+class CliConfigurationError(Exception):
+    """
+    Raised when CLI arguments or environment defaults are invalid.
+    """
+
+
 def _env_flag(name, default=False):
     """
     Parse a boolean environment variable with a fallback default.
@@ -25,6 +31,21 @@ def _env_flag(name, default=False):
     if value is None:
         return default
     return value.lower() in ["true", "1", "yes", "on"]
+
+
+def _env_int(name, default):
+    """
+    Parse an integer environment variable with a clear configuration error.
+    """
+    value = os.environ.get(name)
+    if value is None:
+        return default
+    try:
+        return int(value)
+    except ValueError as error:
+        raise CliConfigurationError(
+            f"Environment variable {name} must be an integer, got {value!r}"
+        ) from error
 
 
 def create_parser():
@@ -46,7 +67,7 @@ def create_parser():
     parser.add_argument(
         "--baudrate",
         help="Serial port baud rate",
-        default=int(os.environ.get("MTR2MQTT_BAUDRATE", 9600)),
+        default=_env_int("MTR2MQTT_BAUDRATE", 9600),
         required=False,
         type=int,
         choices=[9600, 115200],
@@ -81,13 +102,14 @@ def create_parser():
     parser.add_argument(
         "--serial-timeout",
         help="Timeout for serial port (ENV: MTR2MQTT_SERIAL_TIMEOUT)",
-        default=int(os.environ.get("MTR2MQTT_SERIAL_TIMEOUT", 1)),
+        default=_env_int("MTR2MQTT_SERIAL_TIMEOUT", 1),
         required=False,
+        type=int,
     )
     parser.add_argument(
         "--scl-address",
         help="SCL address 0...123 or 126 for broadcast (ENV: MTR2MQTT_SCL_ADDRESS)",
-        default=int(os.environ.get("MTR2MQTT_SCL_ADDRESS", 126)),
+        default=_env_int("MTR2MQTT_SCL_ADDRESS", 126),
         required=False,
         type=int,
         choices=(list(range(124)) + [126]),
@@ -104,8 +126,9 @@ def create_parser():
         "--mqtt-port",
         "-p",
         help="MQTT host port (ENV: MTR2MQTT_MQTT_PORT)",
-        default=int(os.environ.get("MTR2MQTT_MQTT_PORT", 1883)),
+        default=_env_int("MTR2MQTT_MQTT_PORT", 1883),
         required=False,
+        type=int,
     )
     parser.add_argument(
         "--metadata-file",
@@ -216,7 +239,11 @@ def main():
     """
     Main function.
     """
-    args = create_parser().parse_args()
+    try:
+        args = create_parser().parse_args()
+    except CliConfigurationError as error:
+        sys.stderr.write(f"{error}\n")
+        sys.exit(-1)
 
     if args.version:
         print(version("mtr2mqtt"))
@@ -230,7 +257,7 @@ def main():
     )
     try:
         bridge.run_forever()
-    except BridgeError as error:
+    except (BridgeError, metadata.MetadataError, CliConfigurationError) as error:
         logging.fatal(str(error))
         sys.exit(-1)
 

--- a/mtr2mqtt/homeassistant.py
+++ b/mtr2mqtt/homeassistant.py
@@ -289,7 +289,7 @@ class DiscoveryPublisher:
                 result,
             )
             return False
-        except Exception:
+        except (OSError, RuntimeError, TypeError, ValueError, KeyError):
             logging.exception(
                 "Home Assistant discovery publish raised an exception for receiver %s",
                 receiver_serial_number,

--- a/mtr2mqtt/homeassistant.py
+++ b/mtr2mqtt/homeassistant.py
@@ -257,34 +257,41 @@ class DiscoveryPublisher:
         """
         Publish discovery once when the first real measurement arrives.
         """
-        sensor_id = str(measurement["id"])
-        cache_key = (str(receiver_serial_number), sensor_id)
-        if cache_key in self._published:
-            return True
+        try:
+            sensor_id = str(measurement["id"])
+            cache_key = (str(receiver_serial_number), sensor_id)
+            if cache_key in self._published:
+                return True
 
-        topic = discovery_topic(
-            self.discovery_prefix,
-            receiver_serial_number,
-            sensor_id,
-            node_id=self.node_id,
-        )
-        payload = build_discovery_payload(receiver_serial_number, measurement)
-        result, mid = mqtt_client.publish(
-            topic,
-            payload=payload,
-            qos=1,
-            retain=self.retain,
-        )
-        logging.debug("HA discovery publish result: %s, mid: %s", result, mid)
-        if result == 0:
-            self._published.add(cache_key)
-            return True
+            topic = discovery_topic(
+                self.discovery_prefix,
+                receiver_serial_number,
+                sensor_id,
+                node_id=self.node_id,
+            )
+            payload = build_discovery_payload(receiver_serial_number, measurement)
+            result, mid = mqtt_client.publish(
+                topic,
+                payload=payload,
+                qos=1,
+                retain=self.retain,
+            )
+            logging.debug("HA discovery publish result: %s, mid: %s", result, mid)
+            if result == 0:
+                self._published.add(cache_key)
+                return True
 
-        logging.warning(
-            "Sending Home Assistant discovery for receiver %s sensor %s failed "
-            "with result code: %s",
-            receiver_serial_number,
-            sensor_id,
-            result,
-        )
-        return False
+            logging.warning(
+                "Sending Home Assistant discovery for receiver %s sensor %s failed "
+                "with result code: %s",
+                receiver_serial_number,
+                sensor_id,
+                result,
+            )
+            return False
+        except Exception:
+            logging.exception(
+                "Home Assistant discovery publish raised an exception for receiver %s",
+                receiver_serial_number,
+            )
+            return False

--- a/mtr2mqtt/metadata.py
+++ b/mtr2mqtt/metadata.py
@@ -8,28 +8,53 @@ Functions
 """
 
 import logging
-import sys
 import json
 import yaml
+
+
+class MetadataError(Exception):
+    """
+    Raised when transmitter metadata cannot be loaded safely.
+    """
+
 
 def loadfile(file):
     """
     Loads metadata file and returns it as json string
     """
     try:
-        with open(file,'r',encoding="utf-8") as metafile:
+        with open(file, 'r', encoding="utf-8") as metafile:
             transmitter_info = yaml.safe_load(metafile)
             return json.dumps(transmitter_info)
-
-    except FileNotFoundError:
-        logging.exception("File not found")
-        sys.exit(-1)
+    except FileNotFoundError as error:
+        raise MetadataError(f"Metadata file not found: {file}") from error
+    except PermissionError as error:
+        raise MetadataError(f"Metadata file is not readable: {file}") from error
+    except OSError as error:
+        raise MetadataError(f"Unable to read metadata file {file}: {error}") from error
+    except yaml.YAMLError as error:
+        raise MetadataError(f"Metadata file {file} is not valid YAML: {error}") from error
+    except TypeError as error:
+        raise MetadataError(
+            f"Metadata file {file} contains values that cannot be serialized to JSON"
+        ) from error
 
 def get_data(transmitter_id, all_transmitters):
     """
     Gets metada for transmitter
     """
-    all_transmitters = json.loads(all_transmitters)
+    try:
+        all_transmitters = json.loads(all_transmitters)
+    except (TypeError, json.JSONDecodeError):
+        logging.warning("Metadata content is not valid JSON, skipping lookup")
+        return None
+
+    try:
+        transmitter_id = int(transmitter_id)
+    except (TypeError, ValueError):
+        logging.warning("Transmitter id %r is not a valid integer", transmitter_id)
+        return None
+
     logging.debug("All transmitters metadata: %s", all_transmitters)
     logging.debug("Transmitter id: %s", transmitter_id)
     if not isinstance(all_transmitters, list):
@@ -47,7 +72,7 @@ def get_data(transmitter_id, all_transmitters):
             )
             continue
         logging.debug("Iterated transmitter: %s", transmitter)
-        if transmitter.get('id') == int(transmitter_id):
+        if transmitter.get('id') == transmitter_id:
             info = transmitter.copy()
             info.pop('id', None)
             break

--- a/mtr2mqtt/mtr.py
+++ b/mtr2mqtt/mtr.py
@@ -207,25 +207,20 @@ def mtr_response_to_json(payload, transmitters_metadata):
     Optionally adding metadata from a file
     """
 
-    try:
-        headers = _get_header_fields(payload)
-        if headers:
-            data = payload_proressor[headers.transmitter_type](headers, payload)
-            if data is None:
-                return None
+    headers = _get_header_fields(payload)
+    if headers:
+        data = payload_proressor[headers.transmitter_type](headers, payload)
+        if data is None:
+            return None
 
-            if transmitters_metadata:
-                transmitter_information = metadata.get_data(
-                    headers.transmitter_id, transmitters_metadata
-                )
-                logging.debug("Transmitter info: %s", transmitter_information)
-                if transmitter_information:
-                    data_with_transmitter_info = {**data, **transmitter_information}
-                    return json.dumps(data_with_transmitter_info)
-            return json.dumps(data)
-    except Exception:
-        logging.exception("Failed to parse MTR payload: %s", payload)
-        return None
-
+        if transmitters_metadata:
+            transmitter_information = metadata.get_data(
+                headers.transmitter_id, transmitters_metadata
+            )
+            logging.debug("Transmitter info: %s", transmitter_information)
+            if transmitter_information:
+                data_with_transmitter_info = {**data, **transmitter_information}
+                return json.dumps(data_with_transmitter_info)
+        return json.dumps(data)
 
     return None

--- a/mtr2mqtt/mtr.py
+++ b/mtr2mqtt/mtr.py
@@ -40,19 +40,24 @@ def check_payload(payload):
     if payload is None:
         logging.warning("No MTR respose to parse")
         return False
-    if len(payload) > 4:
-        payload_fields = str(payload).split(" ")
-        data_bytes = int(payload_fields[1]) >> 5
-        # Actual payload bytes = received - type - length&voltage - rsl - id
-        received_data_bytes = len(payload_fields)-4
-        if data_bytes == received_data_bytes:
-            return True
-        logging.warning(
-            "Payload size mismatch, expected %s got %s bytes",
-            data_bytes, received_data_bytes
-            )
-    elif len(payload) <= 4:
+    payload_fields = str(payload).split()
+    if len(payload_fields) <= 4:
         logging.warning("Too short payload to process: %s", payload)
+        return False
+    try:
+        data_bytes = int(payload_fields[1]) >> 5
+    except (IndexError, ValueError):
+        logging.warning("Malformed payload length field in payload: %s", payload)
+        return False
+    # Actual payload bytes = received - type - length&voltage - rsl - id
+    received_data_bytes = len(payload_fields) - 4
+    if data_bytes == received_data_bytes:
+        return True
+    logging.warning(
+        "Payload size mismatch, expected %s got %s bytes",
+        data_bytes,
+        received_data_bytes,
+    )
     return False
 
 
@@ -61,13 +66,17 @@ def _get_header_fields(payload):
     Get transmitter type, rsl, id and voltage fields
     """
     if check_payload(payload):
-        payload_fields = str(payload).split(" ")
-        transmitter_type = TransmitterType(int(payload_fields[0])).name
-        battery_voltage = (
-            int(payload_fields[1]) & 31
-        ) / 10  # clear 3 highest bits used for data length (31 = 00011111)
-        transmitter_id = str(payload_fields[3])
-        rsl = (int(payload_fields[2]) & 127) - 127
+        payload_fields = str(payload).split()
+        try:
+            transmitter_type = TransmitterType(int(payload_fields[0])).name
+            battery_voltage = (
+                int(payload_fields[1]) & 31
+            ) / 10  # clear 3 highest bits used for data length (31 = 00011111)
+            transmitter_id = str(payload_fields[3])
+            rsl = (int(payload_fields[2]) & 127) - 127
+        except (IndexError, ValueError):
+            logging.warning("Malformed payload header, skipping payload: %s", payload)
+            return None
         Headers = namedtuple('Headers', 'transmitter_type rsl transmitter_id battery_voltage')
         return Headers(transmitter_type, rsl, transmitter_id, battery_voltage)
     return None
@@ -77,11 +86,15 @@ def _get_ft10_reading(payload):
     Get FT10/MTR260/CSR260 reading from payload
     """
     if check_payload(payload):
-        payload_fields = str(payload).split(" ")
-        reading = round(
-            (int(payload_fields[4]) + int(payload_fields[5]) * 256) / 10.0 - 273.2,
-            1,
-        )
+        payload_fields = str(payload).split()
+        try:
+            reading = round(
+                (int(payload_fields[4]) + int(payload_fields[5]) * 256) / 10.0 - 273.2,
+                1,
+            )
+        except (IndexError, ValueError):
+            logging.warning("Malformed FT10 payload, skipping payload: %s", payload)
+            return None
         return reading
     return None
 
@@ -102,7 +115,7 @@ def _get_utility_data(headers, payload):
     """
     Get Utility packet as json
     """
-    payload_fields = str(payload).split(" ")
+    payload_fields = str(payload).split()
     # Some transmitters may intermittently send some additional
     # information using transmitter type 15.
     # After that, comes a byte indicating the type of utility data,
@@ -115,7 +128,11 @@ def _get_utility_data(headers, payload):
         # Value 0 corresponds to 1.1.2000, and every day increments by one.
         start_date = datetime.strptime("1.1.2000", "%d.%m.%Y")
         logging.debug("Utility packet, payload length: %s", len(payload_fields))
-        calibration_days = int(payload_fields[5]) + 256 * int(payload_fields[6])
+        try:
+            calibration_days = int(payload_fields[5]) + 256 * int(payload_fields[6])
+        except (IndexError, ValueError):
+            logging.warning("Malformed utility payload, skipping payload: %s", payload)
+            return None
         if (
             calibration_days == 65535
         ):
@@ -190,21 +207,25 @@ def mtr_response_to_json(payload, transmitters_metadata):
     Optionally adding metadata from a file
     """
 
-    headers = _get_header_fields(payload)
+    try:
+        headers = _get_header_fields(payload)
+        if headers:
+            data = payload_proressor[headers.transmitter_type](headers, payload)
+            if data is None:
+                return None
 
-    if headers:
-
-        data = payload_proressor[headers.transmitter_type](headers, payload)
-
-        if transmitters_metadata:
-            transmitter_information = metadata.get_data(
-                headers.transmitter_id, transmitters_metadata
-            )
-            logging.debug("Transmitter info: %s", transmitter_information)
-            if transmitter_information:
-                data_with_transmitter_info = {**data, **transmitter_information}
-                return json.dumps(data_with_transmitter_info)
-        return json.dumps(data)
+            if transmitters_metadata:
+                transmitter_information = metadata.get_data(
+                    headers.transmitter_id, transmitters_metadata
+                )
+                logging.debug("Transmitter info: %s", transmitter_information)
+                if transmitter_information:
+                    data_with_transmitter_info = {**data, **transmitter_information}
+                    return json.dumps(data_with_transmitter_info)
+            return json.dumps(data)
+    except Exception:
+        logging.exception("Failed to parse MTR payload: %s", payload)
+        return None
 
 
     return None

--- a/mtr2mqtt/runtime.py
+++ b/mtr2mqtt/runtime.py
@@ -87,8 +87,11 @@ def on_connect(client, userdata, flags, reason_code, properties):
     )
     if reason_code == 0:
         client.connected_flag = True
+        client.connect_error = None
         logging.info("MQTT server connected OK")
     else:
+        client.connected_flag = False
+        client.connect_error = reason_code
         logging.warning("Bad connection Returned code=%s", str(reason_code))
 
 
@@ -122,17 +125,21 @@ def _read_receiver_serial_number(ser, scl_address):
     """
     Query the receiver serial number from an open and validated port.
     """
-    scl_sn_command = scl.create_command("SN ?", scl_address)
-    ser.write(scl_sn_command)
-    logging.debug("Wrote message: %s to: %s", scl_sn_command, ser.name)
-    response = ser.read_until(scl.END_CHAR)
-    response_checksum = bytes(ser.read(1))
-    receiver_serial_number = scl.parse_response(response, response_checksum)
-    if receiver_serial_number:
-        return receiver_serial_number
+    try:
+        scl_sn_command = scl.create_command("SN ?", scl_address)
+        ser.write(scl_sn_command)
+        logging.debug("Wrote message: %s to: %s", scl_sn_command, ser.name)
+        response = ser.read_until(scl.END_CHAR)
+        response_checksum = bytes(ser.read(1))
+        receiver_serial_number = scl.parse_response(response, response_checksum)
+        if receiver_serial_number:
+            return receiver_serial_number
 
-    logging.warning("Unable to read receiver serial number from port %s", ser.name)
-    return None
+        logging.warning("Unable to read receiver serial number from port %s", ser.name)
+        return None
+    except (OSError, serial.serialutil.SerialException):
+        logging.exception("Reading receiver serial number failed on port %s", ser.name)
+        return None
 
 
 def _build_receiver_connection(ser, args, device_type):
@@ -167,7 +174,7 @@ def open_receiver_connection(args):
                 ser.close()
                 return None
             return _build_receiver_connection(ser, args, device_type)
-        except (serial.serialutil.SerialException, ValueError):
+        except (OSError, serial.serialutil.SerialException, ValueError):
             logging.exception("Unable to open serial port")
             raise ReceiverConnectionError(
                 f"Unable to open serial port {args.serial_port}"
@@ -180,7 +187,7 @@ def open_receiver_connection(args):
             if device_type:
                 return _build_receiver_connection(ser, args, device_type)
             ser.close()
-        except serial.serialutil.SerialException:
+        except (OSError, serial.serialutil.SerialException):
             continue
 
     return None
@@ -255,6 +262,8 @@ def open_mqtt_connection(args):
     client.reconnect_delay_set(min_delay=1, max_delay=30)
     client.on_connect = on_connect
     client.on_disconnect = on_disconnect
+    client.connected_flag = False
+    client.connect_error = None
 
     mqtt_host = args.mqtt_host or "localhost"
     mqtt_port = int(args.mqtt_port or 1883)
@@ -263,14 +272,28 @@ def open_mqtt_connection(args):
     print(f"Connecting to MQTT host: {mqtt_host}:{mqtt_port}")
     try:
         client.connect(mqtt_host, mqtt_port)
-        while not client.connected_flag:
+        deadline = time.monotonic() + 30
+        while not client.connected_flag and client.connect_error is None:
             logging.debug("Waiting for MQTT connection")
+            if time.monotonic() >= deadline:
+                raise MqttConnectionError(
+                    f"Timed out waiting for MQTT host {mqtt_host}:{mqtt_port}"
+                )
             time.sleep(1)
-    except (mqtt.socket.timeout, mqtt.socket.error) as error:
+        if client.connect_error is not None:
+            raise MqttConnectionError(
+                "MQTT broker rejected connection to "
+                f"{mqtt_host}:{mqtt_port} with reason code {client.connect_error}"
+            )
+    except (mqtt.socket.timeout, mqtt.socket.error, OSError) as error:
+        client.loop_stop()
         logging.exception("Unable to connect to MQTT host: %s", error)
         raise MqttConnectionError(
             f"Unable to connect to MQTT host {mqtt_host}:{mqtt_port}"
         ) from error
+    except MqttConnectionError:
+        client.loop_stop()
+        raise
     return client
 
 
@@ -283,8 +306,15 @@ def publish_measurement(
     """
     Publish discovery first when enabled, then publish the measurement.
     """
-    measurement = json.loads(measurement_json)
-    sensor_id = measurement["id"]
+    try:
+        measurement = json.loads(measurement_json)
+        sensor_id = measurement["id"]
+    except (TypeError, json.JSONDecodeError, KeyError):
+        logging.exception(
+            "Invalid measurement payload, skipping publish: %s",
+            measurement_json,
+        )
+        return mqtt.MQTT_ERR_INVAL, None
 
     if not getattr(mqtt_client, "connected_flag", True):
         logging.warning(
@@ -295,18 +325,33 @@ def publish_measurement(
         return mqtt.MQTT_ERR_NO_CONN, None
 
     if ha_discovery_publisher:
-        ha_discovery_publisher.publish_if_needed(
-            mqtt_client,
-            receiver_serial_number,
-            measurement,
-        )
+        try:
+            ha_discovery_publisher.publish_if_needed(
+                mqtt_client,
+                receiver_serial_number,
+                measurement,
+            )
+        except Exception:
+            logging.exception(
+                "Home Assistant discovery publish failed for receiver %s sensor %s",
+                receiver_serial_number,
+                sensor_id,
+            )
 
-    result, mid = mqtt_client.publish(
-        homeassistant.state_topic(receiver_serial_number, sensor_id),
-        payload=measurement_json,
-        qos=1,
-        retain=False,
-    )
+    try:
+        result, mid = mqtt_client.publish(
+            homeassistant.state_topic(receiver_serial_number, sensor_id),
+            payload=measurement_json,
+            qos=1,
+            retain=False,
+        )
+    except Exception:
+        logging.exception(
+            "Publishing measurement failed for receiver %s sensor %s",
+            receiver_serial_number,
+            sensor_id,
+        )
+        return mqtt.MQTT_ERR_NO_CONN, None
     logging.debug("publish result: %s, mid: %s", result, mid)
     if result != 0:
         logging.warning(
@@ -346,8 +391,11 @@ class MtrBridge:
         Stop MQTT and close the current serial handle if present.
         """
         if self.mqtt_client is not None:
-            self.mqtt_client.loop_stop()
-            self.mqtt_client.disconnect()
+            try:
+                self.mqtt_client.loop_stop()
+                self.mqtt_client.disconnect()
+            except Exception:
+                logging.debug("MQTT client shutdown raised an exception")
         if self.receiver is not None:
             try:
                 self.receiver.serial_handle.close()
@@ -408,12 +456,19 @@ class MtrBridge:
             return PollResult(BridgeState.IDLE)
 
         self.state = BridgeState.READY
-        return PollResult(
-            BridgeState.READY,
-            measurement_json=mtr.mtr_response_to_json(
+        try:
+            measurement_json = mtr.mtr_response_to_json(
                 parsed_response,
                 self.transmitters_metadata,
-            ),
+            )
+        except Exception:
+            logging.exception("Failed to transform receiver payload into measurement JSON")
+            self.state = BridgeState.IDLE
+            return PollResult(BridgeState.IDLE)
+
+        return PollResult(
+            BridgeState.READY,
+            measurement_json=measurement_json,
         )
 
     def publish_measurement(self, measurement_json):

--- a/mtr2mqtt/runtime.py
+++ b/mtr2mqtt/runtime.py
@@ -325,18 +325,11 @@ def publish_measurement(
         return mqtt.MQTT_ERR_NO_CONN, None
 
     if ha_discovery_publisher:
-        try:
-            ha_discovery_publisher.publish_if_needed(
-                mqtt_client,
-                receiver_serial_number,
-                measurement,
-            )
-        except Exception:
-            logging.exception(
-                "Home Assistant discovery publish failed for receiver %s sensor %s",
-                receiver_serial_number,
-                sensor_id,
-            )
+        ha_discovery_publisher.publish_if_needed(
+            mqtt_client,
+            receiver_serial_number,
+            measurement,
+        )
 
     try:
         result, mid = mqtt_client.publish(
@@ -345,7 +338,7 @@ def publish_measurement(
             qos=1,
             retain=False,
         )
-    except Exception:
+    except (OSError, RuntimeError, TypeError, ValueError):
         logging.exception(
             "Publishing measurement failed for receiver %s sensor %s",
             receiver_serial_number,
@@ -394,7 +387,7 @@ class MtrBridge:
             try:
                 self.mqtt_client.loop_stop()
                 self.mqtt_client.disconnect()
-            except Exception:
+            except (OSError, RuntimeError, TypeError, ValueError):
                 logging.debug("MQTT client shutdown raised an exception")
         if self.receiver is not None:
             try:
@@ -456,15 +449,10 @@ class MtrBridge:
             return PollResult(BridgeState.IDLE)
 
         self.state = BridgeState.READY
-        try:
-            measurement_json = mtr.mtr_response_to_json(
-                parsed_response,
-                self.transmitters_metadata,
-            )
-        except Exception:
-            logging.exception("Failed to transform receiver payload into measurement JSON")
-            self.state = BridgeState.IDLE
-            return PollResult(BridgeState.IDLE)
+        measurement_json = mtr.mtr_response_to_json(
+            parsed_response,
+            self.transmitters_metadata,
+        )
 
         return PollResult(
             BridgeState.READY,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -101,6 +101,16 @@ def test_parser_reads_environment_defaults(monkeypatch):
     assert args.quiet is False
 
 
+def test_parser_rejects_invalid_integer_environment_default(monkeypatch):
+    """
+    Invalid integer environment defaults raise a clear configuration error.
+    """
+    monkeypatch.setenv("MTR2MQTT_MQTT_PORT", "abc")
+
+    with pytest.raises(cli.CliConfigurationError):
+        cli.create_parser()
+
+
 def test_parser_debug_flag_enables_debug():
     """
     The debug flag is parsed as a boolean store_true option.
@@ -180,9 +190,9 @@ def test_parser_parses_common_options():
     )
 
     assert args.mqtt_host == "localhost"
-    assert args.mqtt_port == "1885"
+    assert args.mqtt_port == 1885
     assert args.baudrate == 115200
-    assert args.serial_timeout == "2"
+    assert args.serial_timeout == 2
     assert args.scl_address == 0
     assert args.metadata_file == "tests/metadata.yml"
 
@@ -263,3 +273,16 @@ def test_main_exits_cleanly_when_runtime_startup_fails(monkeypatch):
 
     assert error.value.code == -1
     assert captured["fatal"] == "startup failed"
+
+
+def test_main_exits_cleanly_when_environment_defaults_are_invalid(monkeypatch, capsys):
+    """
+    CLI reports invalid environment defaults without a traceback.
+    """
+    monkeypatch.setenv("MTR2MQTT_MQTT_PORT", "abc")
+
+    with pytest.raises(SystemExit) as error:
+        cli.main()
+
+    assert error.value.code == -1
+    assert "MTR2MQTT_MQTT_PORT must be an integer" in capsys.readouterr().err

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -2,8 +2,8 @@
 Tests for metadata module
 """
 import json
-from pathlib import Path
 
+import pytest
 from context import mtr2mqtt
 from mtr2mqtt import metadata
 
@@ -113,6 +113,25 @@ def test_metadata_loadfile_with_unexpected_mapping_content(tmp_path):
     })
 
 
+def test_metadata_loadfile_raises_for_missing_file():
+    """
+    Missing metadata files raise a typed metadata error.
+    """
+    with pytest.raises(metadata.MetadataError):
+        metadata.loadfile("tests/does-not-exist.yml")
+
+
+def test_metadata_loadfile_raises_for_invalid_yaml(tmp_path):
+    """
+    Invalid YAML metadata is surfaced as a metadata error.
+    """
+    metadata_file = tmp_path / "invalid_metadata.yml"
+    metadata_file.write_text(":\n  bad\n", encoding="utf-8")
+
+    with pytest.raises(metadata.MetadataError):
+        metadata.loadfile(str(metadata_file))
+
+
 def test_metadata_get_data_accepts_string_transmitter_id():
     """
     metadata.get_data converts a string transmitter id to int before lookup.
@@ -121,3 +140,17 @@ def test_metadata_get_data_accepts_string_transmitter_id():
         "2345",
         METADATA_TEST_FILE_OUTPUT
     ) == METADATA_TEST_TRANSMITTER_OUTPUT
+
+
+def test_metadata_get_data_returns_none_for_invalid_json_payload():
+    """
+    Invalid metadata JSON content is ignored.
+    """
+    assert metadata.get_data(2345, "{") is None
+
+
+def test_metadata_get_data_returns_none_for_invalid_transmitter_id():
+    """
+    Invalid transmitter ids do not raise during lookup.
+    """
+    assert metadata.get_data("not-a-number", METADATA_TEST_FILE_OUTPUT) is None

--- a/tests/test_mtr.py
+++ b/tests/test_mtr.py
@@ -44,6 +44,8 @@ MTR_NONE_MESSAGE = None
 MTR_TOO_SHORT_INPUT = "0 90 58 15006"
 MTR_SIZE_MISMATCH_INPUT = "0 122 58 15006 145 11"
 MTR_CSR260_READING_INPUT = "11 90 58 15006 145 11"
+MTR_MALFORMED_LENGTH_INPUT = "0 xx 58 15006 145 11"
+MTR_UNKNOWN_TYPE_INPUT = "99 90 58 15006 145 11"
 
 
 @freeze_time("2020-09-23 19:34:13.497019+00:00")
@@ -96,6 +98,13 @@ def test_check_payload_with_size_mismatch():
     mtr.check_payload returns False when the payload length field does not match.
     """
     assert not mtr.check_payload(MTR_SIZE_MISMATCH_INPUT)
+
+
+def test_check_payload_with_non_numeric_length_field():
+    """
+    Non-numeric payload length fields are rejected.
+    """
+    assert not mtr.check_payload(MTR_MALFORMED_LENGTH_INPUT)
 
 
 def test_get_headers_with_valid_message():
@@ -209,3 +218,17 @@ def test_mtr_response_to_json_returns_none_for_invalid_message():
     Invalid payloads are ignored.
     """
     assert mtr.mtr_response_to_json(MTR_TOO_SHORT_INPUT, None) is None
+
+
+def test_mtr_response_to_json_returns_none_for_malformed_message():
+    """
+    Malformed payload fields are ignored instead of raising.
+    """
+    assert mtr.mtr_response_to_json(MTR_MALFORMED_LENGTH_INPUT, None) is None
+
+
+def test_mtr_response_to_json_returns_none_for_unknown_transmitter_type():
+    """
+    Unknown transmitter types are ignored instead of crashing parsing.
+    """
+    assert mtr.mtr_response_to_json(MTR_UNKNOWN_TYPE_INPUT, None) is None

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -4,6 +4,7 @@ Tests for runtime module.
 
 from types import SimpleNamespace
 
+import pytest
 from context import mtr2mqtt
 from mtr2mqtt import runtime
 
@@ -74,6 +75,9 @@ def test_open_mqtt_connection_raises_mqtt_error_on_connect_failure(monkeypatch):
         def loop_start(self):
             return None
 
+        def loop_stop(self):
+            return None
+
         def connect(self, host, port):
             raise runtime.mqtt.socket.error("boom")
 
@@ -88,6 +92,80 @@ def test_open_mqtt_connection_raises_mqtt_error_on_connect_failure(monkeypatch):
         assert "Unable to connect to MQTT host mqtt.example:1884" == str(error)
     else:
         raise AssertionError("MqttConnectionError was not raised")
+
+
+def test_open_mqtt_connection_raises_on_broker_rejection(monkeypatch):
+    """
+    MQTT broker rejections fail startup instead of hanging indefinitely.
+    """
+
+    class FakeClient:
+        def __init__(self, **kwargs):
+            self.connected_flag = False
+            self.connect_error = None
+
+        def enable_logger(self):
+            return None
+
+        def reconnect_delay_set(self, min_delay, max_delay):
+            return None
+
+        def loop_start(self):
+            return None
+
+        def loop_stop(self):
+            return None
+
+        def connect(self, host, port):
+            runtime.on_connect(self, None, None, 5, None)
+
+    monkeypatch.setattr(runtime.mqtt, "Client", FakeClient)
+    monkeypatch.setattr(runtime.time, "sleep", lambda _: None)
+
+    args = SimpleNamespace(mqtt_host="mqtt.example", mqtt_port=1884)
+
+    with pytest.raises(runtime.MqttConnectionError) as error:
+        runtime.open_mqtt_connection(args)
+
+    assert "reason code 5" in str(error.value)
+
+
+def test_open_mqtt_connection_raises_on_timeout(monkeypatch):
+    """
+    MQTT startup times out when the callback never reports success or failure.
+    """
+    monotonic_values = iter([0, 10, 20, 31])
+
+    class FakeClient:
+        def __init__(self, **kwargs):
+            self.connected_flag = False
+            self.connect_error = None
+
+        def enable_logger(self):
+            return None
+
+        def reconnect_delay_set(self, min_delay, max_delay):
+            return None
+
+        def loop_start(self):
+            return None
+
+        def loop_stop(self):
+            return None
+
+        def connect(self, host, port):
+            return None
+
+    monkeypatch.setattr(runtime.mqtt, "Client", FakeClient)
+    monkeypatch.setattr(runtime.time, "sleep", lambda _: None)
+    monkeypatch.setattr(runtime.time, "monotonic", lambda: next(monotonic_values))
+
+    args = SimpleNamespace(mqtt_host="mqtt.example", mqtt_port=1884)
+
+    with pytest.raises(runtime.MqttConnectionError) as error:
+        runtime.open_mqtt_connection(args)
+
+    assert "Timed out waiting" in str(error.value)
 
 
 def test_open_receiver_connection_rejects_incompatible_explicit_port(monkeypatch):
@@ -252,6 +330,39 @@ def test_publish_measurement_publishes_discovery_first():
     assert client.calls[1][0] == "measurements/RTR970123/15006"
     assert client.calls[1][1]["payload"] == measurement_json
     assert client.calls[1][1]["retain"] is False
+
+
+def test_publish_measurement_rejects_invalid_json_payload():
+    """
+    Invalid measurement payloads are skipped instead of raising.
+    """
+    client = SimpleNamespace(connected_flag=True)
+
+    result, mid = runtime.publish_measurement(client, "RTR970123", "{")
+
+    assert result == runtime.mqtt.MQTT_ERR_INVAL
+    assert mid is None
+
+
+def test_publish_measurement_handles_publish_exceptions():
+    """
+    MQTT publish exceptions are converted to a failed publish result.
+    """
+
+    class FakeClient:
+        connected_flag = True
+
+        def publish(self, *args, **kwargs):
+            raise RuntimeError("boom")
+
+    result, mid = runtime.publish_measurement(
+        FakeClient(),
+        "RTR970123",
+        '{"id": "15006", "reading": 22.9}',
+    )
+
+    assert result == runtime.mqtt.MQTT_ERR_NO_CONN
+    assert mid is None
 
 
 def test_publish_measurement_without_discovery_keeps_normal_publish_behavior():


### PR DESCRIPTION
## Summary
- validate integer CLI environment defaults explicitly and fail startup with clear configuration errors
- replace metadata helper exits with typed errors and tolerate malformed metadata lookups during runtime
- harden receiver parsing, serial probing, MQTT connect, and publish paths so malformed frames and broker failures are logged and skipped instead of hanging or crashing the bridge

## Why
This bridge is intended to run unattended, but several error paths were still brittle. Invalid integer environment variables could crash startup before logging was configured, malformed metadata could abort the process from a helper module, malformed receiver payloads could raise during parsing, and MQTT startup could wait forever if the broker rejected the connection. The goal of this change is to make those failure modes explicit, bounded, and recoverable.

## Impact
- invalid numeric environment variables now fail with a clear startup error instead of an uncaught `ValueError`
- metadata loading now reports missing, unreadable, and invalid YAML files through typed errors
- invalid metadata JSON or transmitter ids are ignored safely during lookup
- malformed receiver payloads and serial-number reads are skipped without terminating the bridge
- MQTT startup now fails fast on broker rejection or connection timeout instead of hanging indefinitely
- measurement and Home Assistant discovery publishes now handle invalid payloads and client exceptions more defensively

## Root Cause
The main issue was inconsistent failure handling across startup and long-running code paths. Some helpers exited the process directly, some parsing logic assumed well-formed input from hardware, and MQTT startup only modeled the success path. That left the daemon vulnerable to configuration mistakes, transient device issues, and broker-side failures.

## Validation
- `uv run pytest`
