### PR TITLE
feat(output): improve runtime output modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ Or define the serial port and mqtt host as parameters:
 mtr2mqtt --serial-port /dev/ttyUSB12345 --mqtt-host 192.168.1.2
 ```
 
+By default, runtime logs are emitted as one JSON object per line. When running in an interactive terminal, JSON keys and values are syntax colored, with standard fields such as `timestamp`, `level`, `logger`, and `message` highlighted consistently. When output is redirected or piped, ANSI color is suppressed so the log stream remains valid JSON.
+
 Enable Home Assistant discovery:
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ mtr2mqtt --serial-port /dev/ttyUSB12345 --mqtt-host 192.168.1.2
 
 By default, runtime logs are emitted as one JSON object per line. When running in an interactive terminal, JSON keys and values are syntax colored, with standard fields such as `timestamp`, `level`, `logger`, and `message` highlighted consistently. When output is redirected or piped, ANSI color is suppressed so the log stream remains valid JSON.
 
+For a human-focused live view, use `--output table`. In this mode, the console shows the latest reading for each sensor in a continuously refreshed table instead of printing each measurement as a log line. The table starts with a stable set of core columns and automatically adds extra columns for additional measurement or metadata fields when they appear. The nested `ha` metadata block is excluded from the table. Table output requires an interactive terminal.
+
 Enable Home Assistant discovery:
 
 ```sh
@@ -46,6 +48,12 @@ Use a custom discovery prefix or node id:
 
 ```sh
 mtr2mqtt --ha-discovery --ha-discovery-prefix ha --ha-discovery-node-id mtr-bridge-1
+```
+
+Use the live table view:
+
+```sh
+mtr2mqtt -f metadata.yml --output table
 ```
 
 ### Using Docker

--- a/mtr2mqtt/cli.py
+++ b/mtr2mqtt/cli.py
@@ -140,6 +140,13 @@ def create_parser():
         type=str,
     )
     parser.add_argument(
+        "--output",
+        help="Console output mode (ENV: MTR2MQTT_OUTPUT)",
+        default=os.environ.get("MTR2MQTT_OUTPUT", "json"),
+        required=False,
+        choices=["json", "table"],
+    )
+    parser.add_argument(
         "--ha-discovery",
         help="Enable Home Assistant MQTT discovery (ENV: MTR2MQTT_HA_DISCOVERY)",
         default=_env_flag("MTR2MQTT_HA_DISCOVERY", False),
@@ -206,7 +213,7 @@ def configure_logging(args):
     if args.debug:
         configure_root_logger(debug=True)
         logging.debug("Debug logging enabled")
-    elif args.quiet:
+    elif args.quiet or args.output == "table":
         configure_root_logger(quiet=True)
     else:
         configure_root_logger()
@@ -249,13 +256,13 @@ def main():
         print(version("mtr2mqtt"))
         sys.exit(0)
 
-    configure_logging(args)
-    bridge = MtrBridge(
-        args,
-        transmitters_metadata=load_metadata(args),
-        discovery_publisher=create_discovery_publisher(args),
-    )
     try:
+        configure_logging(args)
+        bridge = MtrBridge(
+            args,
+            transmitters_metadata=load_metadata(args),
+            discovery_publisher=create_discovery_publisher(args),
+        )
         bridge.run_forever()
     except (BridgeError, metadata.MetadataError, CliConfigurationError) as error:
         logging.fatal(str(error))

--- a/mtr2mqtt/cli.py
+++ b/mtr2mqtt/cli.py
@@ -12,6 +12,7 @@ from serial.serialutil import EIGHTBITS, FIVEBITS, SEVENBITS, SIXBITS
 import serial
 
 from mtr2mqtt import homeassistant
+from mtr2mqtt.logging_utils import configure_root_logger
 from mtr2mqtt import metadata
 from mtr2mqtt.runtime import BridgeError
 from mtr2mqtt.runtime import MtrBridge
@@ -202,14 +203,13 @@ def configure_logging(args):
     """
     Configure logging based on the provided arguments.
     """
-    log_format = "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
     if args.debug:
-        logging.basicConfig(level=logging.DEBUG, format=log_format)
-        print("Debug logging enabled")
+        configure_root_logger(debug=True)
+        logging.debug("Debug logging enabled")
     elif args.quiet:
-        logging.basicConfig(level=logging.WARNING)
+        configure_root_logger(quiet=True)
     else:
-        logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(message)s")
+        configure_root_logger()
         sys.tracebacklimit = 0
 
 

--- a/mtr2mqtt/logging_utils.py
+++ b/mtr2mqtt/logging_utils.py
@@ -1,0 +1,155 @@
+"""
+Structured logging helpers for the CLI and runtime.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+import json
+import logging
+import sys
+
+
+_BASE_LOG_RECORD_KEYS = {
+    "args",
+    "asctime",
+    "created",
+    "exc_info",
+    "exc_text",
+    "filename",
+    "funcName",
+    "levelname",
+    "levelno",
+    "lineno",
+    "module",
+    "msecs",
+    "message",
+    "msg",
+    "name",
+    "pathname",
+    "process",
+    "processName",
+    "relativeCreated",
+    "stack_info",
+    "thread",
+    "threadName",
+    "taskName",
+}
+
+_LEVEL_COLORS = {
+    logging.DEBUG: "\033[38;5;244m",
+    logging.INFO: "\033[1;38;5;81m",
+    logging.WARNING: "\033[1;38;5;214m",
+    logging.ERROR: "\033[1;38;5;203m",
+    logging.CRITICAL: "\033[1;38;5;196m",
+}
+_KEY_COLOR = "\033[38;5;153m"
+_STRING_COLOR = "\033[38;5;253m"
+_NUMBER_COLOR = "\033[38;5;117m"
+_BOOLEAN_COLOR = "\033[38;5;222m"
+_NULL_COLOR = "\033[38;5;244m"
+_FIELD_KEY_COLORS = {
+    "timestamp": "\033[1;38;5;250m",
+    "level": "\033[1;38;5;252m",
+    "logger": "\033[1;38;5;153m",
+    "message": "\033[1;38;5;255m",
+}
+_RESET = "\033[0m"
+
+
+def _supports_color(stream):
+    """
+    Return True when ANSI color is safe for the configured output stream.
+    """
+    return hasattr(stream, "isatty") and stream.isatty()
+
+
+class JsonLogFormatter(logging.Formatter):
+    """
+    Render log records as one JSON object per line.
+    """
+
+    def __init__(self, use_color=False):
+        super().__init__()
+        self.use_color = use_color
+
+    def _colorize_key(self, key):
+        color = _FIELD_KEY_COLORS.get(key, _KEY_COLOR)
+        return f'{color}{json.dumps(key, ensure_ascii=False)}{_RESET}'
+
+    def _colorize_value(self, value, *, parent_key=None):
+        rendered = None
+        if isinstance(value, dict):
+            items = []
+            for child_key in sorted(value):
+                rendered_key = self._colorize_key(child_key)
+                child_rendered = self._colorize_value(
+                    value[child_key],
+                    parent_key=child_key,
+                )
+                items.append(f"{rendered_key}: {child_rendered}")
+            rendered = "{" + ", ".join(items) + "}"
+        elif isinstance(value, list):
+            items = [
+                self._colorize_value(item, parent_key=parent_key)
+                for item in value
+            ]
+            rendered = "[" + ", ".join(items) + "]"
+        elif isinstance(value, bool):
+            rendered = f"{_BOOLEAN_COLOR}{json.dumps(value)}{_RESET}"
+        elif value is None:
+            rendered = f"{_NULL_COLOR}{json.dumps(value)}{_RESET}"
+        elif isinstance(value, (int, float)):
+            rendered = f"{_NUMBER_COLOR}{json.dumps(value)}{_RESET}"
+        else:
+            json_value = json.dumps(value, ensure_ascii=False, default=str)
+            color = _STRING_COLOR
+            if parent_key == "level":
+                color = _LEVEL_COLORS.get(
+                    getattr(logging, str(value), None),
+                    _STRING_COLOR,
+                )
+            rendered = f"{color}{json_value}{_RESET}"
+        return rendered
+
+    def format(self, record):
+        payload = {
+            "timestamp": datetime.fromtimestamp(
+                record.created,
+                tz=timezone.utc,
+            ).isoformat(timespec="milliseconds"),
+            "level": record.levelname,
+            "logger": record.name,
+            "message": record.getMessage(),
+        }
+
+        for key, value in record.__dict__.items():
+            if key in _BASE_LOG_RECORD_KEYS or key.startswith("_"):
+                continue
+            payload[key] = value
+
+        if record.exc_info:
+            payload["exception"] = self.formatException(record.exc_info)
+        if record.stack_info:
+            payload["stack"] = self.formatStack(record.stack_info)
+
+        rendered = json.dumps(payload, ensure_ascii=False, default=str, sort_keys=True)
+        if not self.use_color:
+            return rendered
+
+        return self._colorize_value(payload)
+
+
+def configure_root_logger(*, debug=False, quiet=False, stream=None):
+    """
+    Configure the process root logger for structured console output.
+    """
+    target_stream = stream or sys.stderr
+    level = logging.DEBUG if debug else logging.WARNING if quiet else logging.INFO
+    handler = logging.StreamHandler(target_stream)
+    handler.setFormatter(JsonLogFormatter(use_color=_supports_color(target_stream)))
+
+    root_logger = logging.getLogger()
+    root_logger.handlers.clear()
+    root_logger.setLevel(level)
+    root_logger.addHandler(handler)

--- a/mtr2mqtt/runtime.py
+++ b/mtr2mqtt/runtime.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass
 from enum import Enum
 import json
 import logging
+import sys
 import time
 
 import paho.mqtt.client as mqtt
@@ -17,6 +18,7 @@ from serial.tools import list_ports
 from mtr2mqtt import homeassistant
 from mtr2mqtt import mtr
 from mtr2mqtt import scl
+from mtr2mqtt.table_view import MeasurementTableView
 
 
 SERIAL_PORT_GREP = "RTR|FTR|DCS|DPR"
@@ -38,6 +40,12 @@ class ReceiverConnectionError(BridgeError):
 class MqttConnectionError(BridgeError):
     """
     Raised when the runtime cannot connect to the MQTT broker.
+    """
+
+
+class OutputModeError(BridgeError):
+    """
+    Raised when the selected output mode cannot run in the current terminal.
     """
 
 
@@ -413,7 +421,19 @@ class MtrBridge:
         self.receiver = None
         self.mqtt_client = None
         self.state = BridgeState.STARTING
-        self.scl_dbg_1_command = scl.create_command("DBG 1 ?", args.scl_address)
+        self.output_view = self._create_output_view()
+
+    def _create_output_view(self):
+        if getattr(self.args, "output", "json") != "table":
+            return None
+        if not sys.stdout.isatty():
+            raise OutputModeError(
+                "Table output requires an interactive terminal"
+            )
+        return MeasurementTableView()
+
+    def _poll_command(self):
+        return scl.create_command("DBG 1 ?", self.args.scl_address)
 
     def start(self):
         """
@@ -461,10 +481,11 @@ class MtrBridge:
 
         parsed_response = None
         try:
-            receiver.serial_handle.write(self.scl_dbg_1_command)
+            poll_command = self._poll_command()
+            receiver.serial_handle.write(poll_command)
             logging.debug(
                 "Wrote message: %s to: to %s",
-                self.scl_dbg_1_command,
+                poll_command,
                 receiver.serial_handle.name,
             )
             response = receiver.serial_handle.read_until(scl.END_CHAR)
@@ -528,7 +549,13 @@ class MtrBridge:
             while True:
                 poll_result = self.poll_once()
                 if poll_result.measurement_json:
-                    log_measurement(poll_result.measurement_json)
+                    if self.output_view is not None:
+                        self.output_view.update(
+                            self.receiver.receiver_serial_number,
+                            poll_result.measurement_json,
+                        )
+                    else:
+                        log_measurement(poll_result.measurement_json)
                     self.publish_measurement(poll_result.measurement_json)
                     continue
                 if poll_result.state in {

--- a/mtr2mqtt/runtime.py
+++ b/mtr2mqtt/runtime.py
@@ -20,6 +20,7 @@ from mtr2mqtt import scl
 
 
 SERIAL_PORT_GREP = "RTR|FTR|DCS|DPR"
+LOGGER = logging.getLogger(__name__)
 
 
 class BridgeError(Exception):
@@ -88,7 +89,13 @@ def on_connect(client, userdata, flags, reason_code, properties):
     if reason_code == 0:
         client.connected_flag = True
         client.connect_error = None
-        logging.info("MQTT server connected OK")
+        LOGGER.info(
+            "MQTT broker connected",
+            extra={
+                "event": "mqtt_connected",
+                "mqtt_reason_code": str(reason_code),
+            },
+        )
     else:
         client.connected_flag = False
         client.connect_error = reason_code
@@ -148,8 +155,15 @@ def _build_receiver_connection(ser, args, device_type):
         ser.close()
         return None
 
-    print(f"Connected device type: {device_type}")
-    print(f"Receiver S/N: {receiver_serial_number}")
+    LOGGER.info(
+        "Receiver connected",
+        extra={
+            "event": "receiver_connected",
+            "device_type": device_type,
+            "receiver_serial_number": receiver_serial_number,
+            "serial_port": ser.name,
+        },
+    )
     return ReceiverConnection(
         serial_handle=ser,
         device_type=device_type,
@@ -269,7 +283,14 @@ def open_mqtt_connection(args):
     mqtt_port = int(args.mqtt_port or 1883)
 
     client.loop_start()
-    print(f"Connecting to MQTT host: {mqtt_host}:{mqtt_port}")
+    LOGGER.info(
+        "Connecting to MQTT broker",
+        extra={
+            "event": "mqtt_connecting",
+            "mqtt_host": mqtt_host,
+            "mqtt_port": mqtt_port,
+        },
+    )
     try:
         client.connect(mqtt_host, mqtt_port)
         deadline = time.monotonic() + 30
@@ -295,6 +316,31 @@ def open_mqtt_connection(args):
         client.loop_stop()
         raise
     return client
+
+
+def log_measurement(measurement_json):
+    """
+    Log a measurement payload as a structured JSON record.
+    """
+    try:
+        measurement = json.loads(measurement_json)
+    except (TypeError, json.JSONDecodeError):
+        LOGGER.info(
+            "Measurement received",
+            extra={
+                "event": "measurement_received",
+                "measurement_raw": measurement_json,
+            },
+        )
+        return
+
+    LOGGER.info(
+        "Measurement received",
+        extra={
+            "event": "measurement_received",
+            "measurement": measurement,
+        },
+    )
 
 
 def publish_measurement(
@@ -482,7 +528,7 @@ class MtrBridge:
             while True:
                 poll_result = self.poll_once()
                 if poll_result.measurement_json:
-                    logging.info(poll_result.measurement_json)
+                    log_measurement(poll_result.measurement_json)
                     self.publish_measurement(poll_result.measurement_json)
                     continue
                 if poll_result.state in {

--- a/mtr2mqtt/table_view.py
+++ b/mtr2mqtt/table_view.py
@@ -1,0 +1,264 @@
+"""
+Live table rendering for human-facing terminal output.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+import json
+import shutil
+import sys
+
+
+CORE_COLUMNS = [
+    "receiver",
+    "id",
+    "location",
+    "quantity",
+    "reading",
+    "unit",
+    "battery",
+    "rsl",
+    "timestamp",
+]
+OPTIONAL_COLUMNS = [
+    "type",
+    "description",
+    "zone",
+    "calibrated",
+    "message",
+    "utility",
+]
+HIDDEN_COLUMNS = {"ha"}
+HEADER_COLOR = "\033[1;38;5;255m"
+TITLE_COLOR = "\033[1;38;5;81m"
+COUNT_COLOR = "\033[38;5;250m"
+SEPARATOR_COLOR = "\033[38;5;240m"
+ID_COLOR = "\033[1;38;5;117m"
+READING_COLOR = "\033[38;5;121m"
+STATUS_COLOR = "\033[38;5;222m"
+TIMESTAMP_COLOR = "\033[38;5;250m"
+RESET = "\033[0m"
+PREFERRED_WIDTHS = {
+    "id": 8,
+    "reading": 10,
+    "battery": 7,
+    "rsl": 6,
+    "timestamp": 25,
+}
+MAX_WIDTHS = {
+    "receiver": 16,
+    "id": 8,
+    "location": 20,
+    "quantity": 16,
+    "reading": 10,
+    "unit": 8,
+    "battery": 7,
+    "rsl": 6,
+    "timestamp": 25,
+    "type": 12,
+    "description": 24,
+    "zone": 18,
+    "calibrated": 12,
+    "message": 24,
+    "utility": 24,
+}
+
+
+def _display_value(value):
+    if value is None:
+        return ""
+    if isinstance(value, (dict, list)):
+        return json.dumps(value, ensure_ascii=False, sort_keys=True)
+    return str(value)
+
+
+def _format_timestamp(value):
+    rendered = _display_value(value)
+    normalized = rendered.replace("Z", "+00:00")
+    try:
+        timestamp = datetime.fromisoformat(normalized)
+    except ValueError:
+        return rendered
+    return timestamp.isoformat(sep=" ", timespec="seconds")
+
+
+class MeasurementTableView:
+    """
+    Maintain the latest measurement per sensor and redraw a terminal table.
+    """
+
+    def __init__(self, stream=None, use_color=None):
+        self.stream = stream or sys.stdout
+        self.rows = {}
+        self.dynamic_columns = []
+        self.use_color = (
+            hasattr(self.stream, "isatty") and self.stream.isatty()
+            if use_color is None
+            else use_color
+        )
+
+    def update(self, receiver_serial_number, measurement_json):
+        """
+        Merge a measurement into the latest-state table and redraw it.
+        """
+        measurement = json.loads(measurement_json)
+        row = {
+            key: value
+            for key, value in measurement.items()
+            if key not in HIDDEN_COLUMNS
+        }
+        row["receiver"] = receiver_serial_number
+        sensor_id = str(row.get("id", "unknown"))
+        row_key = (receiver_serial_number, sensor_id)
+        self.rows[row_key] = row
+
+        known_columns = set(CORE_COLUMNS + OPTIONAL_COLUMNS + self.dynamic_columns)
+        for key in sorted(row):
+            if key not in known_columns:
+                self.dynamic_columns.append(key)
+                known_columns.add(key)
+
+        self.render()
+
+    def render(self):
+        """
+        Draw the full table for the current latest sensor state.
+        """
+        columns = self._columns()
+        rows = self._sorted_rows()
+        terminal_width = shutil.get_terminal_size((120, 24)).columns
+
+        lines = [
+            self._colorize("mtr2mqtt live table", TITLE_COLOR),
+            self._colorize(f"Sensors: {len(rows)}", COUNT_COLOR),
+            "",
+            self._render_header(columns, terminal_width),
+            self._render_separator(columns, terminal_width),
+        ]
+        for row in rows:
+            lines.append(self._render_row(columns, row, terminal_width))
+
+        self.stream.write("\x1b[H\x1b[2J")
+        self.stream.write("\n".join(lines))
+        self.stream.write("\n")
+        self.stream.flush()
+
+    def _columns(self):
+        columns = []
+        for name in CORE_COLUMNS + OPTIONAL_COLUMNS + self.dynamic_columns:
+            if any(name in row for row in self.rows.values()) and name not in columns:
+                columns.append(name)
+        return columns
+
+    def _sorted_rows(self):
+        return [
+            self.rows[key]
+            for key in sorted(
+                self.rows,
+                key=lambda item: (
+                    self._sort_id(item[1]),
+                    str(item[1]),
+                    str(item[0]),
+                ),
+            )
+        ]
+
+    def _sort_id(self, sensor_id):
+        return int(sensor_id) if str(sensor_id).isdigit() else float("inf")
+
+    def _render_separator(self, columns, terminal_width):
+        widths = self._column_widths(columns, terminal_width)
+        separator = "-+-".join("-" * widths[column] for column in columns)
+        return self._colorize(separator, SEPARATOR_COLOR)
+
+    def _render_header(self, columns, terminal_width):
+        widths = self._column_widths(columns, terminal_width)
+        cells = [
+            self._colorize(column.ljust(widths[column]), HEADER_COLOR)
+            for column in columns
+        ]
+        return " | ".join(cells)
+
+    def _render_row(self, columns, values, terminal_width):
+        widths = self._column_widths(columns, terminal_width)
+        rendered_cells = []
+        for column in columns:
+            value = self._cell_value(column, values).replace("\n", " ")
+            fitted = self._fit(value, widths[column])
+            rendered_cells.append(self._colorize_cell(column, fitted))
+        return " | ".join(rendered_cells)
+
+    def _column_widths(self, columns, terminal_width):
+        min_widths = {column: self._min_width(column) for column in columns}
+        rows = self._sorted_rows()
+        widths = {
+            column: self._desired_width(column, rows, min_widths[column])
+            for column in columns
+        }
+
+        table_width = sum(widths.values()) + max(0, len(columns) - 1) * 3
+        while (
+            table_width > terminal_width
+            and any(width > min_widths[column] for column, width in widths.items())
+        ):
+            widest_column = self._widest_shrinkable_column(
+                columns,
+                widths,
+                min_widths,
+            )
+            if widths[widest_column] <= min_widths[widest_column]:
+                break
+            widths[widest_column] -= 1
+            table_width -= 1
+        return widths
+
+    def _min_width(self, column):
+        return max(len(column), min(6, PREFERRED_WIDTHS.get(column, 6)))
+
+    def _desired_width(self, column, rows, min_width):
+        sample_values = [_display_value(row.get(column, "")) for row in rows]
+        value_lengths = [len(value) for value in sample_values]
+        widest = max([len(column), *value_lengths], default=len(column))
+        preferred = PREFERRED_WIDTHS.get(column, widest)
+        max_width = MAX_WIDTHS.get(column, 24)
+        return min(max(min_width, widest, preferred), max_width)
+
+    def _widest_shrinkable_column(self, columns, widths, min_widths):
+        shrinkable_columns = [
+            column for column in columns if widths[column] > min_widths[column]
+        ]
+        preferred_columns = [
+            column for column in shrinkable_columns if column != "timestamp"
+        ]
+        candidate_columns = preferred_columns or shrinkable_columns
+        return max(candidate_columns, key=lambda column: widths[column])
+
+    def _cell_value(self, column, values):
+        if column == "timestamp":
+            return _format_timestamp(values.get(column, ""))
+        return _display_value(values.get(column, ""))
+
+    def _fit(self, value, width):
+        if len(value) <= width:
+            return value.ljust(width)
+        if width <= 1:
+            return value[:width]
+        return value[: width - 1] + "…"
+
+    def _colorize(self, text, color):
+        if not self.use_color:
+            return text
+        return f"{color}{text}{RESET}"
+
+    def _colorize_cell(self, column, text):
+        color = None
+        if column == "id":
+            color = ID_COLOR
+        elif column in {"reading", "unit"}:
+            color = READING_COLOR
+        elif column in {"battery", "rsl", "type"}:
+            color = STATUS_COLOR
+        elif column == "timestamp":
+            color = TIMESTAMP_COLOR
+        return self._colorize(text, color) if color else text

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -39,6 +39,7 @@ def test_parser_defaults_without_arguments(monkeypatch):
     monkeypatch.delenv("MTR2MQTT_MQTT_HOST", raising=False)
     monkeypatch.delenv("MTR2MQTT_MQTT_PORT", raising=False)
     monkeypatch.delenv("MTR2MQTT_METADATA_FILE", raising=False)
+    monkeypatch.delenv("MTR2MQTT_OUTPUT", raising=False)
     monkeypatch.delenv("MTR2MQTT_HA_DISCOVERY", raising=False)
     monkeypatch.delenv("MTR2MQTT_HA_DISCOVERY_PREFIX", raising=False)
     monkeypatch.delenv("MTR2MQTT_HA_DISCOVERY_RETAIN", raising=False)
@@ -56,6 +57,7 @@ def test_parser_defaults_without_arguments(monkeypatch):
     assert args.mqtt_host is None
     assert args.mqtt_port == 1883
     assert args.metadata_file is None
+    assert args.output == "json"
     assert args.ha_discovery is False
     assert args.ha_discovery_prefix == "homeassistant"
     assert args.ha_discovery_retain is True
@@ -76,6 +78,7 @@ def test_parser_reads_environment_defaults(monkeypatch):
     monkeypatch.setenv("MTR2MQTT_MQTT_HOST", "mqtt.example")
     monkeypatch.setenv("MTR2MQTT_MQTT_PORT", "1884")
     monkeypatch.setenv("MTR2MQTT_METADATA_FILE", "tests/metadata.yml")
+    monkeypatch.setenv("MTR2MQTT_OUTPUT", "table")
     monkeypatch.setenv("MTR2MQTT_HA_DISCOVERY", "true")
     monkeypatch.setenv("MTR2MQTT_HA_DISCOVERY_PREFIX", "ha")
     monkeypatch.setenv("MTR2MQTT_HA_DISCOVERY_RETAIN", "false")
@@ -93,6 +96,7 @@ def test_parser_reads_environment_defaults(monkeypatch):
     assert args.mqtt_host == "mqtt.example"
     assert args.mqtt_port == 1884
     assert args.metadata_file == "tests/metadata.yml"
+    assert args.output == "table"
     assert args.ha_discovery is True
     assert args.ha_discovery_prefix == "ha"
     assert args.ha_discovery_retain is False
@@ -186,6 +190,8 @@ def test_parser_parses_common_options():
             "0",
             "--metadata-file",
             "tests/metadata.yml",
+            "--output",
+            "table",
         ]
     )
 
@@ -195,6 +201,7 @@ def test_parser_parses_common_options():
     assert args.serial_timeout == 2
     assert args.scl_address == 0
     assert args.metadata_file == "tests/metadata.yml"
+    assert args.output == "table"
 
 
 def test_parser_rejects_invalid_scl_address():

--- a/tests/test_logging_utils.py
+++ b/tests/test_logging_utils.py
@@ -1,0 +1,55 @@
+"""
+Tests for structured logging helpers.
+"""
+
+import io
+import json
+import logging
+
+from context import mtr2mqtt
+from mtr2mqtt import logging_utils
+
+
+def test_configure_root_logger_writes_json_records():
+    """
+    Default logging uses a JSON formatter that keeps redirected output parseable.
+    """
+    stream = io.StringIO()
+    logging_utils.configure_root_logger(stream=stream)
+
+    logger = logging.getLogger("mtr2mqtt.test")
+    logger.info("Receiver connected", extra={"event": "receiver_connected"})
+
+    payload = json.loads(stream.getvalue().strip())
+
+    assert payload["level"] == "INFO"
+    assert payload["logger"] == "mtr2mqtt.test"
+    assert payload["message"] == "Receiver connected"
+    assert payload["event"] == "receiver_connected"
+
+
+def test_json_formatter_can_colorize_tty_output():
+    """
+    Interactive console output colorizes keys and values by type.
+    """
+    formatter = logging_utils.JsonLogFormatter(use_color=True)
+    record = logging.LogRecord(
+        name="mtr2mqtt.test",
+        level=logging.WARNING,
+        pathname=__file__,
+        lineno=1,
+        msg="warning message",
+        args=(),
+        exc_info=None,
+    )
+    record.sensor_id = 15006
+    record.connected = True
+
+    formatted = formatter.format(record)
+
+    assert formatted.startswith("{")
+    assert '\033[1;38;5;250m"timestamp"\033[0m' in formatted
+    assert '\033[1;38;5;252m"level"\033[0m' in formatted
+    assert '\033[1;38;5;214m"WARNING"\033[0m' in formatted
+    assert '\033[38;5;153m"sensor_id"\033[0m: \033[38;5;117m15006\033[0m' in formatted
+    assert '\033[38;5;153m"connected"\033[0m: \033[38;5;222mtrue\033[0m' in formatted

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -251,6 +251,18 @@ def test_open_receiver_connection_raises_receiver_error_for_open_failure(monkeyp
         raise AssertionError("ReceiverConnectionError was not raised")
 
 
+def test_bridge_table_output_requires_tty(monkeypatch):
+    """
+    Table mode is rejected when stdout is not an interactive terminal.
+    """
+    monkeypatch.setattr(runtime.sys.stdout, "isatty", lambda: False)
+
+    with pytest.raises(runtime.OutputModeError) as error:
+        runtime.MtrBridge(SimpleNamespace(scl_address=126, output="table"))
+
+    assert "interactive terminal" in str(error.value)
+
+
 def test_recover_receiver_connection_rediscovery_finds_replugged_receiver(monkeypatch):
     """
     Autodetect mode rescans for a receiver when reopening the old port fails.

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -168,6 +168,29 @@ def test_open_mqtt_connection_raises_on_timeout(monkeypatch):
     assert "Timed out waiting" in str(error.value)
 
 
+def test_on_connect_logs_reason_code_objects_without_crashing(caplog):
+    """
+    Successful MQTT connects must tolerate ReasonCode-like callback objects.
+    """
+
+    class FakeReasonCode:
+        def __eq__(self, other):
+            return other == 0
+
+        def __str__(self):
+            return "Success"
+
+    client = SimpleNamespace(connected_flag=False, connect_error="previous")
+
+    with caplog.at_level("INFO"):
+        runtime.on_connect(client, None, None, FakeReasonCode(), None)
+
+    assert client.connected_flag is True
+    assert client.connect_error is None
+    assert caplog.records[0].event == "mqtt_connected"
+    assert caplog.records[0].mqtt_reason_code == "Success"
+
+
 def test_open_receiver_connection_rejects_incompatible_explicit_port(monkeypatch):
     """
     Explicit ports must still validate as compatible receivers.
@@ -398,6 +421,44 @@ def test_publish_measurement_without_discovery_keeps_normal_publish_behavior():
             {"payload": measurement_json, "qos": 1, "retain": False},
         )
     ]
+
+
+def test_log_measurement_adds_structured_measurement_payload(caplog):
+    """
+    Measurement logs carry the parsed payload as structured data.
+    """
+    with caplog.at_level("INFO"):
+        runtime.log_measurement('{"id":"15006","reading":22.9,"location":"Kids room"}')
+
+    assert caplog.records[0].event == "measurement_received"
+    assert caplog.records[0].measurement["id"] == "15006"
+    assert caplog.records[0].measurement["location"] == "Kids room"
+
+
+def test_build_receiver_connection_logs_structured_receiver_details(monkeypatch, caplog):
+    """
+    Receiver connection logs expose the device and serial identity as fields.
+    """
+
+    class FakeSerial:
+        name = "/dev/cu.usbserial-test"
+
+        def get_settings(self):
+            return {"baudrate": 9600}
+
+    monkeypatch.setattr(runtime, "_read_receiver_serial_number", lambda *_args: "A118636")
+
+    with caplog.at_level("INFO"):
+        receiver = runtime._build_receiver_connection(
+            FakeSerial(),
+            SimpleNamespace(scl_address=126),
+            "RTR970 V3.0",
+        )
+
+    assert receiver.receiver_serial_number == "A118636"
+    assert caplog.records[0].event == "receiver_connected"
+    assert caplog.records[0].device_type == "RTR970 V3.0"
+    assert caplog.records[0].serial_port == "/dev/cu.usbserial-test"
 
 
 def test_bridge_recovers_and_uses_refreshed_receiver_serial_number(monkeypatch):

--- a/tests/test_table_view.py
+++ b/tests/test_table_view.py
@@ -1,0 +1,125 @@
+"""
+Tests for the live table renderer.
+"""
+
+import io
+import os
+
+from context import mtr2mqtt
+from mtr2mqtt.table_view import MeasurementTableView
+
+
+def test_table_view_adds_dynamic_columns_from_measurements(monkeypatch):
+    """
+    Extra measurement fields become visible as new columns automatically.
+    """
+    stream = io.StringIO()
+    view = MeasurementTableView(stream=stream)
+    monkeypatch.setattr(
+        "mtr2mqtt.table_view.shutil.get_terminal_size",
+        lambda *args, **kwargs: os.terminal_size((160, 24)),
+    )
+
+    view.update(
+        "RTR970123",
+        (
+            '{"id":"15006","reading":22.7,"location":"Kids room",'
+            '"zone":"Indoor","custom":"value","ha":{"name":"ignored"}}'
+        ),
+    )
+
+    rendered = stream.getvalue()
+
+    assert "receiver" in rendered
+    assert "custom" in rendered
+    assert "RTR970123" in rendered
+    assert "Kids room" in rendered
+    assert "value" in rendered
+    assert '"name":"ignored"' not in rendered
+
+
+def test_table_view_keeps_latest_reading_for_sensor(monkeypatch):
+    """
+    The table redraw only shows the latest row per receiver and sensor id.
+    """
+    stream = io.StringIO()
+    view = MeasurementTableView(stream=stream)
+    monkeypatch.setattr(
+        "mtr2mqtt.table_view.shutil.get_terminal_size",
+        lambda *args, **kwargs: os.terminal_size((160, 24)),
+    )
+
+    view.update("RTR970123", '{"id":"15006","reading":22.7}')
+    view.update("RTR970123", '{"id":"15006","reading":23.1}')
+
+    rendered = stream.getvalue().split("\x1b[H\x1b[2J")[-1]
+
+    assert "23.1" in rendered
+    assert "22.7" not in rendered
+
+
+def test_table_view_sorts_rows_by_numeric_sensor_id(monkeypatch):
+    """
+    Rows are ordered by sensor id rather than location or receiver name.
+    """
+    stream = io.StringIO()
+    view = MeasurementTableView(stream=stream)
+    monkeypatch.setattr(
+        "mtr2mqtt.table_view.shutil.get_terminal_size",
+        lambda *args, **kwargs: os.terminal_size((160, 24)),
+    )
+
+    view.update("RTR970123", '{"id":"15010","location":"B room","reading":20.0}')
+    view.update("RTR970123", '{"id":"15002","location":"A room","reading":21.0}')
+
+    rendered = stream.getvalue().split("\x1b[H\x1b[2J")[-1]
+    assert rendered.index("15002") < rendered.index("15010")
+
+
+def test_table_view_formats_timestamp_to_second_precision(monkeypatch):
+    """
+    The table timestamp view drops sub-second precision while keeping timezone.
+    """
+    stream = io.StringIO()
+    view = MeasurementTableView(stream=stream)
+    monkeypatch.setattr(
+        "mtr2mqtt.table_view.shutil.get_terminal_size",
+        lambda *args, **kwargs: os.terminal_size((160, 24)),
+    )
+
+    full_timestamp = "2026-04-18 19:36:09.629822+00:00"
+    displayed_timestamp = "2026-04-18 19:36:09+00:00"
+    view.update(
+        "RTR970123",
+        (
+            '{"id":"15006","reading":22.7,"timestamp":"'
+            + full_timestamp
+            + '","location":"Kids room"}'
+        ),
+    )
+
+    rendered = stream.getvalue().split("\x1b[H\x1b[2J")[-1]
+    assert displayed_timestamp in rendered
+    assert full_timestamp not in rendered
+
+
+def test_table_view_can_colorize_headers_and_cells(monkeypatch):
+    """
+    Table view can apply ANSI coloring for interactive terminals.
+    """
+    stream = io.StringIO()
+    view = MeasurementTableView(stream=stream, use_color=True)
+    monkeypatch.setattr(
+        "mtr2mqtt.table_view.shutil.get_terminal_size",
+        lambda *args, **kwargs: os.terminal_size((160, 24)),
+    )
+
+    view.update(
+        "RTR970123",
+        '{"id":"15006","reading":22.7,"unit":"°C","timestamp":"2026-04-18T19:36:09+00:00"}',
+    )
+
+    rendered = stream.getvalue()
+    assert "\033[1;38;5;255m" in rendered
+    assert "\033[1;38;5;117m" in rendered
+    assert "\033[38;5;121m" in rendered


### PR DESCRIPTION
## What changed

This PR improves operator-facing runtime output in two modes:

- adds structured JSON logging with TTY-aware syntax coloring for normal console output
- adds an optional `--output table` mode that keeps a live latest-value table per sensor

## Why it changed

The existing output mixed plain log lines, raw prints, and full JSON payloads in a way that was hard to scan during normal operation. The new JSON logging keeps the default output machine-friendly while making it easier to read interactively, and the table mode provides a dedicated human-focused monitor view when a live dashboard is preferable to scrolling logs.

## Impact

- default output is now one JSON object per line
- interactive JSON output uses restrained ANSI syntax coloring
- `--output table` shows a live table sorted by sensor id
- dynamic table columns include additional measurement and metadata fields except the nested `ha` block
- table timestamps are rendered at second precision for readability

## Validation

- `make test`
- `make lint`
