### PR TITLE
fix(docker): reduce runtime image size

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,16 @@
+.git
+.github
+.pytest_cache
+.venv
+__pycache__/
+*.py[cod]
+*.egg-info/
+build/
+dist/
+docs/
+tests/
+metadata.yml
+sample_metadata.yml
+docker-compose.yml
+CHANGELOG.md
+AGENTS.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,26 @@
-FROM python:3.14-slim
+FROM python:3.14-alpine AS builder
 
-WORKDIR /app
+WORKDIR /src
 
-RUN apt-get update && \
-    apt-get install --only-upgrade -y \
-        libssl3t64 \
-        openssl \
-        openssl-provider-legacy && \
-    rm -rf /var/lib/apt/lists/*
-
-COPY . /app
+COPY pyproject.toml README.md /src/
+COPY mtr2mqtt /src/mtr2mqtt
 
 RUN python -m pip install --no-cache-dir --upgrade \
     pip \
-    "setuptools>=78.1.1" \
+    "setuptools>=80" \
     "wheel>=0.46.2" && \
-    python -m pip install --no-cache-dir .
+    python -m pip wheel --no-cache-dir --wheel-dir /tmp/wheels /src
+
+FROM python:3.14-alpine
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+RUN apk upgrade --no-cache
+
+COPY --from=builder /tmp/wheels /tmp/wheels
+
+RUN python -m pip install --no-cache-dir --no-compile /tmp/wheels/*.whl && \
+    rm -rf /tmp/wheels
 
 ENTRYPOINT ["mtr2mqtt"]


### PR DESCRIPTION
## What changed

Reduced the Docker runtime image size by switching to a multi-stage Alpine build and installing only the built wheel into the final image. Added a `.dockerignore` so local development artifacts and repository metadata are excluded from the Docker build context.

## Why

The Docker image is the main deployment path for this project, and smaller images reduce update time and bandwidth usage in constrained environments such as Raspberry Pi Zero W deployments.

## Impact

The runtime image no longer includes the full repository, local virtualenv contents, tests, docs, or build artifacts. The Docker build context is also much smaller.

## Validation

- `make test`
- `docker build -t mtr2mqtt:test .`

## Notes

- Rebuilt image size was `82.7MB`, down from roughly `150MB`
- Runtime behavior on actual serial hardware was not re-verified locally
