### PR TITLE
feat(status): publish retained availability state

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ By default, runtime logs are emitted as one JSON object per line. When running i
 
 For a human-focused live view, use `--output table`. In this mode, the console shows the latest reading for each sensor in a continuously refreshed table instead of printing each measurement as a log line. The table starts with a stable set of core columns and automatically adds extra columns for additional measurement or metadata fields when they appear. The nested `ha` metadata block is excluded from the table. Table output requires an interactive terminal.
 
+The table view also includes sensor availability status. It shows the latest textual status and numeric status code, and timeout-driven offline transitions are reflected even when no fresh readings arrive.
+
 Enable Home Assistant discovery:
 
 ```sh
@@ -48,6 +50,12 @@ Use a custom discovery prefix or node id:
 
 ```sh
 mtr2mqtt --ha-discovery --ha-discovery-prefix ha --ha-discovery-node-id mtr-bridge-1
+```
+
+Configure the offline timeout used by retained status topics and table status:
+
+```sh
+mtr2mqtt --offline-timeout 1800
 ```
 
 Use the live table view:
@@ -180,6 +188,55 @@ measurements/<receiver_serial_number>/<sensor_id>
 Where `<receiver_serial_number>` is the serial number of the receiver and `<sensor_id>` is the unique identifier for the sensor.
 
 This measurement topic structure remains unchanged even when Home Assistant discovery is enabled.
+
+### Status Topics
+
+mtr2mqtt also publishes retained status payloads for observed receivers and sensors:
+
+```text
+status/<receiver_serial_number>
+status/<receiver_serial_number>/<sensor_id>
+```
+
+Receiver status example:
+
+```json
+{
+  "entity_type": "receiver",
+  "receiver": "receiver-a",
+  "status": "online",
+  "status_code": 1,
+  "last_received_at": "2026-04-26T10:15:32Z",
+  "last_publish_at": "2026-04-26T10:15:33Z",
+  "error_count": 0
+}
+```
+
+Sensor status example:
+
+```json
+{
+  "entity_type": "sensor",
+  "receiver": "receiver-a",
+  "sensor": "sensor-123",
+  "status": "offline",
+  "status_code": 0,
+  "last_received_at": "2026-04-26T08:42:10Z",
+  "last_publish_at": "2026-04-26T08:42:10Z",
+  "error_count": 2
+}
+```
+
+Status values use this exact numeric mapping:
+
+- `offline` = `0`
+- `online` = `1`
+
+An entity is `online` after it has been observed at least once and the last valid traffic is within the configured offline timeout. It becomes `offline` after the timeout passes. The default offline timeout is 30 minutes (`1800` seconds) and can be changed with `--offline-timeout` or `MTR2MQTT_OFFLINE_TIMEOUT`.
+
+Status topics are retained so downstream tooling can evaluate current receiver and sensor availability immediately after subscribing. Numeric `status_code` values are intended for simple alert conditions in tools such as `tvallas/mqtt-alerts`.
+
+Never-seen sensors are not fabricated at startup and do not publish offline status. Measurement topics and payloads are intentionally left untouched when a receiver or sensor goes offline: mtr2mqtt does not publish synthetic `null`, `0`, `"offline"`, or any other fake reading to `measurements/...`.
 
 ### Home Assistant MQTT Discovery
 

--- a/mtr2mqtt/cli.py
+++ b/mtr2mqtt/cli.py
@@ -108,6 +108,14 @@ def create_parser():
         type=int,
     )
     parser.add_argument(
+        "--offline-timeout",
+        help="Seconds before observed receivers or sensors are marked offline "
+        "(ENV: MTR2MQTT_OFFLINE_TIMEOUT)",
+        default=_env_int("MTR2MQTT_OFFLINE_TIMEOUT", 30 * 60),
+        required=False,
+        type=int,
+    )
+    parser.add_argument(
         "--scl-address",
         help="SCL address 0...123 or 126 for broadcast (ENV: MTR2MQTT_SCL_ADDRESS)",
         default=_env_int("MTR2MQTT_SCL_ADDRESS", 126),

--- a/mtr2mqtt/runtime.py
+++ b/mtr2mqtt/runtime.py
@@ -18,11 +18,13 @@ from serial.tools import list_ports
 from mtr2mqtt import homeassistant
 from mtr2mqtt import mtr
 from mtr2mqtt import scl
+from mtr2mqtt import status
 from mtr2mqtt.table_view import MeasurementTableView
 
 
 SERIAL_PORT_GREP = "RTR|FTR|DCS|DPR"
 LOGGER = logging.getLogger(__name__)
+STATUS_SWEEP_INTERVAL = 60
 
 
 class BridgeError(Exception):
@@ -409,7 +411,29 @@ def publish_measurement(
     return result, mid
 
 
-class MtrBridge:
+def publish_status(mqtt_client, topic, payload):
+    """
+    Publish a retained status payload.
+    """
+    if not getattr(mqtt_client, "connected_flag", True):
+        logging.warning("Skipping status publish for %s because MQTT is disconnected", topic)
+        return mqtt.MQTT_ERR_NO_CONN, None
+
+    try:
+        result, mid = mqtt_client.publish(
+            topic,
+            payload=json.dumps(payload, sort_keys=True),
+            qos=1,
+            retain=True,
+        )
+    except (OSError, RuntimeError, TypeError, ValueError):
+        logging.exception("Publishing status failed for topic %s", topic)
+        return mqtt.MQTT_ERR_NO_CONN, None
+    logging.debug("status publish result: %s, mid: %s", result, mid)
+    return result, mid
+
+
+class MtrBridge:  # pylint: disable=too-many-instance-attributes
     """
     Long-running runtime for polling an MTR receiver and publishing to MQTT.
     """
@@ -422,6 +446,10 @@ class MtrBridge:
         self.mqtt_client = None
         self.state = BridgeState.STARTING
         self.output_view = self._create_output_view()
+        self.status_tracker = status.StatusTracker(
+            offline_timeout=getattr(self.args, "offline_timeout", 30 * 60),
+        )
+        self._last_status_sweep = 0
 
     def _create_output_view(self):
         if getattr(self.args, "output", "json") != "table":
@@ -540,6 +568,45 @@ class MtrBridge:
             ha_discovery_publisher=self.discovery_publisher,
         )
 
+    def _status_topic(self, payload):
+        if payload["entity_type"] == "receiver":
+            return status.receiver_status_topic(payload["receiver"])
+        return status.sensor_status_topic(payload["receiver"], payload["sensor"])
+
+    def publish_status_changes(self, now=None):
+        """
+        Publish retained status payloads whose content changed.
+        """
+        if self.mqtt_client is None:
+            return []
+
+        published = []
+        for key, payload, rendered in self.status_tracker.changed_payloads(now):
+            result, mid = publish_status(
+                self.mqtt_client,
+                self._status_topic(payload),
+                payload,
+            )
+            if result == mqtt.MQTT_ERR_SUCCESS:
+                self.status_tracker.mark_status_published(key, rendered)
+                published.append((payload, mid))
+        return published
+
+    def sweep_status(self, force=False, now=None):
+        """
+        Detect timeout-driven status changes and update MQTT/table output.
+        """
+        monotonic_now = time.monotonic()
+        if not force and monotonic_now - self._last_status_sweep < STATUS_SWEEP_INTERVAL:
+            return []
+
+        self._last_status_sweep = monotonic_now
+        now = now or status.utc_now()
+        published = self.publish_status_changes(now)
+        if self.output_view is not None:
+            self.output_view.update_statuses(self.status_tracker.sensor_payloads(now))
+        return published
+
     def run_forever(self):
         """
         Start the runtime and keep polling until interrupted.
@@ -547,16 +614,43 @@ class MtrBridge:
         self.start()
         try:
             while True:
+                self.sweep_status()
                 poll_result = self.poll_once()
                 if poll_result.measurement_json:
+                    measurement = json.loads(poll_result.measurement_json)
+                    receiver_serial_number = self.receiver.receiver_serial_number
+                    sensor_id = measurement["id"]
+                    now = status.utc_now()
+                    self.status_tracker.record_observation(
+                        receiver_serial_number,
+                        sensor_id,
+                        observed_at=now,
+                    )
                     if self.output_view is not None:
                         self.output_view.update(
-                            self.receiver.receiver_serial_number,
+                            receiver_serial_number,
                             poll_result.measurement_json,
+                            status_payload=self.status_tracker.sensor_payload(
+                                receiver_serial_number,
+                                sensor_id,
+                                now,
+                            ),
                         )
                     else:
                         log_measurement(poll_result.measurement_json)
-                    self.publish_measurement(poll_result.measurement_json)
+                    result, _mid = self.publish_measurement(poll_result.measurement_json)
+                    if result == mqtt.MQTT_ERR_SUCCESS:
+                        self.status_tracker.record_publish_success(
+                            receiver_serial_number,
+                            sensor_id,
+                            published_at=status.utc_now(),
+                        )
+                    else:
+                        self.status_tracker.record_error(
+                            receiver_serial_number,
+                            sensor_id,
+                        )
+                    self.publish_status_changes()
                     continue
                 if poll_result.state in {
                     BridgeState.IDLE,

--- a/mtr2mqtt/status.py
+++ b/mtr2mqtt/status.py
@@ -1,0 +1,202 @@
+"""
+Receiver and sensor availability status tracking.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from datetime import timezone
+import json
+
+
+STATUS_TOPIC_PREFIX = "status"
+STATUS_ONLINE = "online"
+STATUS_OFFLINE = "offline"
+STATUS_CODES = {
+    STATUS_OFFLINE: 0,
+    STATUS_ONLINE: 1,
+}
+
+
+def utc_now():
+    """
+    Return the current UTC time as a timezone-aware datetime.
+    """
+    return datetime.now(timezone.utc)
+
+
+def format_timestamp(value):
+    """
+    Format a datetime as an RFC 3339 UTC timestamp.
+    """
+    if value is None:
+        return None
+    return value.astimezone(timezone.utc).isoformat(timespec="seconds").replace(
+        "+00:00",
+        "Z",
+    )
+
+
+def receiver_status_topic(receiver, prefix=STATUS_TOPIC_PREFIX):
+    """
+    Build the retained receiver status topic.
+    """
+    return f"{prefix}/{receiver}"
+
+
+def sensor_status_topic(receiver, sensor, prefix=STATUS_TOPIC_PREFIX):
+    """
+    Build the retained sensor status topic.
+    """
+    return f"{prefix}/{receiver}/{sensor}"
+
+
+@dataclass
+class EntityStatus:
+    """
+    Availability state for one receiver or sensor.
+    """
+
+    entity_type: str
+    receiver: str
+    sensor: str | None = None
+    last_received_at: datetime | None = None
+    last_publish_at: datetime | None = None
+    error_count: int = 0
+    last_status_payload: str | None = None
+
+    def status(self, now, offline_timeout):
+        """
+        Return the textual status for this entity at the given time.
+        """
+        if (
+            self.last_received_at is not None
+            and (now - self.last_received_at).total_seconds() <= offline_timeout
+        ):
+            return STATUS_ONLINE
+        return STATUS_OFFLINE
+
+    def payload(self, now, offline_timeout):
+        """
+        Serialize the current status payload as a dictionary.
+        """
+        status = self.status(now, offline_timeout)
+        payload = {
+            "entity_type": self.entity_type,
+            "receiver": self.receiver,
+            "status": status,
+            "status_code": STATUS_CODES[status],
+            "last_received_at": format_timestamp(self.last_received_at),
+            "last_publish_at": format_timestamp(self.last_publish_at),
+            "error_count": self.error_count,
+        }
+        if self.sensor is not None:
+            payload["sensor"] = self.sensor
+        return payload
+
+
+class StatusTracker:
+    """
+    Track receiver and sensor availability independently.
+    """
+
+    def __init__(self, offline_timeout=30 * 60):
+        self.offline_timeout = offline_timeout
+        self.receivers = {}
+        self.sensors = {}
+
+    def record_observation(self, receiver, sensor, observed_at=None):
+        """
+        Record valid traffic for a receiver and one sensor.
+        """
+        observed_at = observed_at or utc_now()
+        receiver_state = self._receiver(receiver)
+        sensor_state = self._sensor(receiver, sensor)
+        receiver_state.last_received_at = observed_at
+        sensor_state.last_received_at = observed_at
+
+    def record_publish_success(self, receiver, sensor, published_at=None):
+        """
+        Record a successful measurement publish for a receiver and sensor.
+        """
+        published_at = published_at or utc_now()
+        self._receiver(receiver).last_publish_at = published_at
+        self._sensor(receiver, sensor).last_publish_at = published_at
+
+    def record_error(self, receiver, sensor=None):
+        """
+        Increment attributable receiver and optional sensor error counters.
+        """
+        self._receiver(receiver).error_count += 1
+        if sensor is not None:
+            self._sensor(receiver, sensor).error_count += 1
+
+    def changed_payloads(self, now=None):
+        """
+        Return status payloads whose serialized content changed since publish.
+        """
+        now = now or utc_now()
+        changed = []
+        for key, state in self._states():
+            payload = state.payload(now, self.offline_timeout)
+            rendered = json.dumps(payload, sort_keys=True, separators=(",", ":"))
+            if rendered != state.last_status_payload:
+                changed.append((key, payload, rendered))
+        return changed
+
+    def mark_status_published(self, key, rendered_payload):
+        """
+        Mark a changed status payload as successfully published.
+        """
+        self._state_by_key(key).last_status_payload = rendered_payload
+
+    def sensor_payloads(self, now=None):
+        """
+        Return current status payloads for all observed sensors.
+        """
+        now = now or utc_now()
+        return [
+            state.payload(now, self.offline_timeout)
+            for _key, state in sorted(self.sensors.items())
+        ]
+
+    def sensor_payload(self, receiver, sensor, now=None):
+        """
+        Return the current status payload for one observed sensor.
+        """
+        now = now or utc_now()
+        return self._sensor(receiver, sensor).payload(now, self.offline_timeout)
+
+    def _receiver(self, receiver):
+        receiver = str(receiver)
+        if receiver not in self.receivers:
+            self.receivers[receiver] = EntityStatus(
+                entity_type="receiver",
+                receiver=receiver,
+            )
+        return self.receivers[receiver]
+
+    def _sensor(self, receiver, sensor):
+        receiver = str(receiver)
+        sensor = str(sensor)
+        key = (receiver, sensor)
+        if key not in self.sensors:
+            self.sensors[key] = EntityStatus(
+                entity_type="sensor",
+                receiver=receiver,
+                sensor=sensor,
+            )
+        return self.sensors[key]
+
+    def _states(self):
+        for receiver, state in sorted(self.receivers.items()):
+            yield ("receiver", receiver, None), state
+        for (receiver, sensor), state in sorted(self.sensors.items()):
+            yield ("sensor", receiver, sensor), state
+
+    def _state_by_key(self, key):
+        entity_type, receiver, sensor = key
+        if entity_type == "receiver":
+            return self.receivers[receiver]
+        return self.sensors[(receiver, sensor)]

--- a/mtr2mqtt/table_view.py
+++ b/mtr2mqtt/table_view.py
@@ -14,7 +14,6 @@ CORE_COLUMNS = [
     "receiver",
     "id",
     "status",
-    "status_code",
     "location",
     "quantity",
     "reading",
@@ -44,7 +43,6 @@ RESET = "\033[0m"
 PREFERRED_WIDTHS = {
     "id": 8,
     "status": 7,
-    "status_code": 11,
     "reading": 10,
     "battery": 7,
     "rsl": 6,
@@ -54,7 +52,6 @@ MAX_WIDTHS = {
     "receiver": 16,
     "id": 8,
     "status": 7,
-    "status_code": 11,
     "location": 20,
     "quantity": 16,
     "reading": 10,
@@ -120,7 +117,6 @@ class MeasurementTableView:
         row_key = (receiver_serial_number, sensor_id)
         if status_payload:
             row["status"] = status_payload.get("status")
-            row["status_code"] = status_payload.get("status_code")
         self.rows[row_key] = row
 
         known_columns = set(CORE_COLUMNS + OPTIONAL_COLUMNS + self.dynamic_columns)
@@ -146,10 +142,9 @@ class MeasurementTableView:
             if row_key not in self.rows:
                 continue
             row = self.rows[row_key]
-            for column in ("status", "status_code"):
-                if row.get(column) != status_payload.get(column):
-                    row[column] = status_payload.get(column)
-                    changed = True
+            if row.get("status") != status_payload.get("status"):
+                row["status"] = status_payload.get("status")
+                changed = True
         if changed:
             self.render()
 
@@ -289,7 +284,7 @@ class MeasurementTableView:
             color = ID_COLOR
         elif column in {"reading", "unit"}:
             color = READING_COLOR
-        elif column in {"battery", "rsl", "type", "status", "status_code"}:
+        elif column in {"battery", "rsl", "type", "status"}:
             color = STATUS_COLOR
         elif column == "timestamp":
             color = TIMESTAMP_COLOR

--- a/mtr2mqtt/table_view.py
+++ b/mtr2mqtt/table_view.py
@@ -13,6 +13,8 @@ import sys
 CORE_COLUMNS = [
     "receiver",
     "id",
+    "status",
+    "status_code",
     "location",
     "quantity",
     "reading",
@@ -41,6 +43,8 @@ TIMESTAMP_COLOR = "\033[38;5;250m"
 RESET = "\033[0m"
 PREFERRED_WIDTHS = {
     "id": 8,
+    "status": 7,
+    "status_code": 11,
     "reading": 10,
     "battery": 7,
     "rsl": 6,
@@ -49,6 +53,8 @@ PREFERRED_WIDTHS = {
 MAX_WIDTHS = {
     "receiver": 16,
     "id": 8,
+    "status": 7,
+    "status_code": 11,
     "location": 20,
     "quantity": 16,
     "reading": 10,
@@ -98,7 +104,7 @@ class MeasurementTableView:
             else use_color
         )
 
-    def update(self, receiver_serial_number, measurement_json):
+    def update(self, receiver_serial_number, measurement_json, status_payload=None):
         """
         Merge a measurement into the latest-state table and redraw it.
         """
@@ -108,9 +114,13 @@ class MeasurementTableView:
             for key, value in measurement.items()
             if key not in HIDDEN_COLUMNS
         }
+        receiver_serial_number = str(receiver_serial_number)
         row["receiver"] = receiver_serial_number
         sensor_id = str(row.get("id", "unknown"))
         row_key = (receiver_serial_number, sensor_id)
+        if status_payload:
+            row["status"] = status_payload.get("status")
+            row["status_code"] = status_payload.get("status_code")
         self.rows[row_key] = row
 
         known_columns = set(CORE_COLUMNS + OPTIONAL_COLUMNS + self.dynamic_columns)
@@ -120,6 +130,28 @@ class MeasurementTableView:
                 known_columns.add(key)
 
         self.render()
+
+    def update_statuses(self, status_payloads):
+        """
+        Merge status-only updates into existing sensor rows and redraw if changed.
+        """
+        changed = False
+        for status_payload in status_payloads:
+            if status_payload.get("entity_type") != "sensor":
+                continue
+            row_key = (
+                str(status_payload.get("receiver")),
+                str(status_payload.get("sensor")),
+            )
+            if row_key not in self.rows:
+                continue
+            row = self.rows[row_key]
+            for column in ("status", "status_code"):
+                if row.get(column) != status_payload.get(column):
+                    row[column] = status_payload.get(column)
+                    changed = True
+        if changed:
+            self.render()
 
     def render(self):
         """
@@ -257,7 +289,7 @@ class MeasurementTableView:
             color = ID_COLOR
         elif column in {"reading", "unit"}:
             color = READING_COLOR
-        elif column in {"battery", "rsl", "type"}:
+        elif column in {"battery", "rsl", "type", "status", "status_code"}:
             color = STATUS_COLOR
         elif column == "timestamp":
             color = TIMESTAMP_COLOR

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -35,6 +35,7 @@ def test_parser_defaults_without_arguments(monkeypatch):
     monkeypatch.delenv("MTR2MQTT_SERIAL_PORT", raising=False)
     monkeypatch.delenv("MTR2MQTT_BAUDRATE", raising=False)
     monkeypatch.delenv("MTR2MQTT_SERIAL_TIMEOUT", raising=False)
+    monkeypatch.delenv("MTR2MQTT_OFFLINE_TIMEOUT", raising=False)
     monkeypatch.delenv("MTR2MQTT_SCL_ADDRESS", raising=False)
     monkeypatch.delenv("MTR2MQTT_MQTT_HOST", raising=False)
     monkeypatch.delenv("MTR2MQTT_MQTT_PORT", raising=False)
@@ -53,6 +54,7 @@ def test_parser_defaults_without_arguments(monkeypatch):
     assert args.serial_port is None
     assert args.baudrate == 9600
     assert args.serial_timeout == 1
+    assert args.offline_timeout == 1800
     assert args.scl_address == 126
     assert args.mqtt_host is None
     assert args.mqtt_port == 1883
@@ -74,6 +76,7 @@ def test_parser_reads_environment_defaults(monkeypatch):
     monkeypatch.setenv("MTR2MQTT_SERIAL_PORT", "/dev/ttyUSB0")
     monkeypatch.setenv("MTR2MQTT_BAUDRATE", "115200")
     monkeypatch.setenv("MTR2MQTT_SERIAL_TIMEOUT", "5")
+    monkeypatch.setenv("MTR2MQTT_OFFLINE_TIMEOUT", "120")
     monkeypatch.setenv("MTR2MQTT_SCL_ADDRESS", "1")
     monkeypatch.setenv("MTR2MQTT_MQTT_HOST", "mqtt.example")
     monkeypatch.setenv("MTR2MQTT_MQTT_PORT", "1884")
@@ -92,6 +95,7 @@ def test_parser_reads_environment_defaults(monkeypatch):
     assert args.serial_port == "/dev/ttyUSB0"
     assert args.baudrate == 115200
     assert args.serial_timeout == 5
+    assert args.offline_timeout == 120
     assert args.scl_address == 1
     assert args.mqtt_host == "mqtt.example"
     assert args.mqtt_port == 1884

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -3,6 +3,9 @@ Tests for runtime module.
 """
 
 from types import SimpleNamespace
+from datetime import datetime
+from datetime import timezone
+import json
 
 import pytest
 from context import mtr2mqtt
@@ -433,6 +436,98 @@ def test_publish_measurement_without_discovery_keeps_normal_publish_behavior():
             {"payload": measurement_json, "qos": 1, "retain": False},
         )
     ]
+
+
+def test_publish_status_uses_retained_status_topic_payload():
+    """
+    Status publishing is retained and separate from measurement publishing.
+    """
+
+    class FakeClient:
+        def __init__(self):
+            self.calls = []
+
+        def publish(self, topic, **kwargs):
+            self.calls.append((topic, kwargs))
+            return (0, 1)
+
+    client = FakeClient()
+    payload = {
+        "entity_type": "sensor",
+        "receiver": "RTR970123",
+        "sensor": "15006",
+        "status": "online",
+        "status_code": 1,
+        "last_received_at": "2026-04-26T10:15:32Z",
+        "last_publish_at": "2026-04-26T10:15:33Z",
+        "error_count": 0,
+    }
+
+    result, mid = runtime.publish_status(
+        client,
+        "status/RTR970123/15006",
+        payload,
+    )
+
+    assert result == 0
+    assert mid == 1
+    assert client.calls[0][0] == "status/RTR970123/15006"
+    assert client.calls[0][1]["qos"] == 1
+    assert client.calls[0][1]["retain"] is True
+    assert json.loads(client.calls[0][1]["payload"]) == payload
+
+
+def test_bridge_publishes_measurement_unchanged_and_retained_status(monkeypatch):
+    """
+    Bridge status publishing is additive and does not alter measurement payloads.
+    """
+
+    class FakeClient:
+        def __init__(self):
+            self.calls = []
+
+        def publish(self, topic, **kwargs):
+            self.calls.append((topic, kwargs))
+            return (0, len(self.calls))
+
+    observed_at = datetime(2026, 4, 26, 10, 15, 32, tzinfo=timezone.utc)
+    published_at = datetime(2026, 4, 26, 10, 15, 33, tzinfo=timezone.utc)
+    times = iter([observed_at, published_at, published_at])
+    measurement_json = '{"id":"15006","reading":22.9}'
+    bridge = runtime.MtrBridge(SimpleNamespace(scl_address=126, offline_timeout=1800))
+    bridge.receiver = runtime.ReceiverConnection(
+        serial_handle=SimpleNamespace(),
+        device_type="RTR970",
+        receiver_serial_number="RTR970123",
+        serial_config={},
+    )
+    bridge.mqtt_client = FakeClient()
+
+    monkeypatch.setattr(runtime.status, "utc_now", lambda: next(times))
+
+    measurement = json.loads(measurement_json)
+    receiver = bridge.receiver.receiver_serial_number
+    bridge.status_tracker.record_observation(receiver, measurement["id"], observed_at)
+    result, _mid = bridge.publish_measurement(measurement_json)
+    if result == runtime.mqtt.MQTT_ERR_SUCCESS:
+        bridge.status_tracker.record_publish_success(
+            receiver,
+            measurement["id"],
+            published_at,
+        )
+    bridge.publish_status_changes()
+
+    assert bridge.mqtt_client.calls[0] == (
+        "measurements/RTR970123/15006",
+        {"payload": measurement_json, "qos": 1, "retain": False},
+    )
+    status_topics = [topic for topic, _kwargs in bridge.mqtt_client.calls[1:]]
+    assert status_topics == ["status/RTR970123", "status/RTR970123/15006"]
+    for _topic, kwargs in bridge.mqtt_client.calls[1:]:
+        assert kwargs["retain"] is True
+        payload = json.loads(kwargs["payload"])
+        assert payload["status"] == "online"
+        assert payload["status_code"] == 1
 
 
 def test_log_measurement_adds_structured_measurement_payload(caplog):

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -1,0 +1,166 @@
+"""
+Tests for receiver and sensor status tracking.
+"""
+
+from datetime import datetime
+from datetime import timedelta
+from datetime import timezone
+
+from context import mtr2mqtt
+from mtr2mqtt import status
+
+
+def test_receiver_and_sensor_mark_online_after_first_reading():
+    """
+    First valid traffic marks both receiver and sensor online.
+    """
+    tracker = status.StatusTracker(offline_timeout=60)
+    observed_at = datetime(2026, 4, 26, 10, 15, 32, tzinfo=timezone.utc)
+
+    tracker.record_observation("receiver-a", "sensor-123", observed_at=observed_at)
+
+    receiver_payload = tracker.receivers["receiver-a"].payload(
+        observed_at,
+        tracker.offline_timeout,
+    )
+    sensor_payload = tracker.sensors[("receiver-a", "sensor-123")].payload(
+        observed_at,
+        tracker.offline_timeout,
+    )
+    assert receiver_payload["status"] == "online"
+    assert receiver_payload["status_code"] == 1
+    assert sensor_payload["status"] == "online"
+    assert sensor_payload["status_code"] == 1
+    assert sensor_payload["last_received_at"] == "2026-04-26T10:15:32Z"
+
+
+def test_receiver_and_sensor_become_offline_after_timeout():
+    """
+    Observed entities transition to offline after the configured timeout.
+    """
+    tracker = status.StatusTracker(offline_timeout=60)
+    observed_at = datetime(2026, 4, 26, 10, 15, 32, tzinfo=timezone.utc)
+    tracker.record_observation("receiver-a", "sensor-123", observed_at=observed_at)
+
+    before_timeout = observed_at + timedelta(seconds=60)
+    after_timeout = observed_at + timedelta(seconds=61)
+
+    assert (
+        tracker.receivers["receiver-a"].payload(
+            before_timeout,
+            tracker.offline_timeout,
+        )["status"]
+        == "online"
+    )
+    assert (
+        tracker.sensors[("receiver-a", "sensor-123")].payload(
+            before_timeout,
+            tracker.offline_timeout,
+        )["status"]
+        == "online"
+    )
+    receiver_payload = tracker.receivers["receiver-a"].payload(
+        after_timeout,
+        tracker.offline_timeout,
+    )
+    sensor_payload = tracker.sensors[("receiver-a", "sensor-123")].payload(
+        after_timeout,
+        tracker.offline_timeout,
+    )
+    assert receiver_payload["status"] == "offline"
+    assert receiver_payload["status_code"] == 0
+    assert sensor_payload["status"] == "offline"
+    assert sensor_payload["status_code"] == 0
+
+
+def test_last_publish_at_updates_only_on_successful_publish_record():
+    """
+    Publish timestamps are separate from valid traffic observations.
+    """
+    tracker = status.StatusTracker(offline_timeout=60)
+    observed_at = datetime(2026, 4, 26, 10, 15, 32, tzinfo=timezone.utc)
+    published_at = datetime(2026, 4, 26, 10, 15, 33, tzinfo=timezone.utc)
+
+    tracker.record_observation("receiver-a", "sensor-123", observed_at=observed_at)
+    payload = tracker.sensors[("receiver-a", "sensor-123")].payload(
+        observed_at,
+        tracker.offline_timeout,
+    )
+    assert payload["last_publish_at"] is None
+
+    tracker.record_publish_success(
+        "receiver-a",
+        "sensor-123",
+        published_at=published_at,
+    )
+    payload = tracker.sensors[("receiver-a", "sensor-123")].payload(
+        published_at,
+        tracker.offline_timeout,
+    )
+    assert payload["last_publish_at"] == "2026-04-26T10:15:33Z"
+
+
+def test_error_count_increments_on_attributed_error():
+    """
+    Attributed errors are counted for the receiver and sensor.
+    """
+    tracker = status.StatusTracker(offline_timeout=60)
+    tracker.record_observation("receiver-a", "sensor-123")
+
+    tracker.record_error("receiver-a", "sensor-123")
+
+    assert tracker.receivers["receiver-a"].error_count == 1
+    assert tracker.sensors[("receiver-a", "sensor-123")].error_count == 1
+
+
+def test_status_topics_are_separate_from_measurement_topics():
+    """
+    Status topics use the status namespace rather than measurements.
+    """
+    assert status.receiver_status_topic("receiver-a") == "status/receiver-a"
+    assert (
+        status.sensor_status_topic("receiver-a", "sensor-123")
+        == "status/receiver-a/sensor-123"
+    )
+
+
+def test_never_seen_sensor_does_not_publish_offline_state():
+    """
+    The tracker only emits status payloads for observed entities.
+    """
+    tracker = status.StatusTracker(offline_timeout=60)
+
+    assert tracker.changed_payloads() == []
+    assert tracker.sensor_payloads() == []
+
+
+def test_status_transition_payloads_publish_only_when_content_changes():
+    """
+    Repeated sweeps do not emit duplicate unchanged payloads.
+    """
+    tracker = status.StatusTracker(offline_timeout=60)
+    observed_at = datetime(2026, 4, 26, 10, 15, 32, tzinfo=timezone.utc)
+    tracker.record_observation("receiver-a", "sensor-123", observed_at=observed_at)
+
+    first = tracker.changed_payloads(observed_at)
+    assert len(first) == 2
+    for key, _payload, rendered in first:
+        tracker.mark_status_published(key, rendered)
+
+    assert tracker.changed_payloads(observed_at + timedelta(seconds=30)) == []
+    offline = tracker.changed_payloads(observed_at + timedelta(seconds=61))
+    assert len(offline) == 2
+    assert {payload["status_code"] for _key, payload, _rendered in offline} == {0}
+
+
+def test_textual_and_numeric_status_are_consistent():
+    """
+    The numeric status code always matches the textual status.
+    """
+    tracker = status.StatusTracker(offline_timeout=60)
+    observed_at = datetime(2026, 4, 26, 10, 15, 32, tzinfo=timezone.utc)
+    tracker.record_observation("receiver-a", "sensor-123", observed_at=observed_at)
+
+    for checked_at in (observed_at, observed_at + timedelta(seconds=61)):
+        for _key, payload, _rendered in tracker.changed_payloads(checked_at):
+            assert payload["status_code"] == status.STATUS_CODES[payload["status"]]

--- a/tests/test_table_view.py
+++ b/tests/test_table_view.py
@@ -123,3 +123,60 @@ def test_table_view_can_colorize_headers_and_cells(monkeypatch):
     assert "\033[1;38;5;255m" in rendered
     assert "\033[1;38;5;117m" in rendered
     assert "\033[38;5;121m" in rendered
+
+
+def test_table_view_includes_status_information(monkeypatch):
+    """
+    Measurement rows can show textual and numeric status.
+    """
+    stream = io.StringIO()
+    view = MeasurementTableView(stream=stream)
+    monkeypatch.setattr(
+        "mtr2mqtt.table_view.shutil.get_terminal_size",
+        lambda *args, **kwargs: os.terminal_size((160, 24)),
+    )
+
+    view.update(
+        "RTR970123",
+        '{"id":"15006","reading":22.7}',
+        status_payload={"status": "online", "status_code": 1},
+    )
+
+    rendered = stream.getvalue().split("\x1b[H\x1b[2J")[-1]
+    assert "status" in rendered
+    assert "status_code" in rendered
+    assert "online" in rendered
+    assert "1" in rendered
+
+
+def test_table_view_reflects_offline_status_transition(monkeypatch):
+    """
+    Status-only updates redraw existing rows when a sensor times out.
+    """
+    stream = io.StringIO()
+    view = MeasurementTableView(stream=stream)
+    monkeypatch.setattr(
+        "mtr2mqtt.table_view.shutil.get_terminal_size",
+        lambda *args, **kwargs: os.terminal_size((160, 24)),
+    )
+
+    view.update(
+        "RTR970123",
+        '{"id":"15006","reading":22.7}',
+        status_payload={"status": "online", "status_code": 1},
+    )
+    view.update_statuses(
+        [
+            {
+                "entity_type": "sensor",
+                "receiver": "RTR970123",
+                "sensor": "15006",
+                "status": "offline",
+                "status_code": 0,
+            }
+        ]
+    )
+
+    rendered = stream.getvalue().split("\x1b[H\x1b[2J")[-1]
+    assert "offline" in rendered
+    assert "online" not in rendered

--- a/tests/test_table_view.py
+++ b/tests/test_table_view.py
@@ -127,7 +127,7 @@ def test_table_view_can_colorize_headers_and_cells(monkeypatch):
 
 def test_table_view_includes_status_information(monkeypatch):
     """
-    Measurement rows can show textual and numeric status.
+    Measurement rows show human-readable status.
     """
     stream = io.StringIO()
     view = MeasurementTableView(stream=stream)
@@ -144,9 +144,8 @@ def test_table_view_includes_status_information(monkeypatch):
 
     rendered = stream.getvalue().split("\x1b[H\x1b[2J")[-1]
     assert "status" in rendered
-    assert "status_code" in rendered
     assert "online" in rendered
-    assert "1" in rendered
+    assert "status_code" not in rendered
 
 
 def test_table_view_reflects_offline_status_transition(monkeypatch):


### PR DESCRIPTION
## Summary

Adds retained MQTT status topics for observed receivers and sensors:

```text
status/<receiver>
status/<receiver>/<sensor>
```

Each status payload includes textual `status`, numeric `status_code`, receive/publish timestamps, and attributed error counts.

## Why

This exposes operational availability separately from measurement data so downstream tooling such as `tvallas/mqtt-alerts` can alert on offline receivers and sensors without interpreting measurement payloads.

## Non-breaking behavior

Measurement topics under `measurements/...` are unchanged. Measurement payloads are unchanged. Offline transitions do not publish synthetic readings, nulls, zeroes, or offline strings to measurement topics.

## Numeric status

Status codes use the exact mapping:

- `offline = 0`
- `online = 1`

These numeric values support simple alert conditions.

## Table output

`--output table` now shows human-readable sensor status and reflects timeout-driven offline transitions. Numeric `status_code` remains in MQTT status payloads but is intentionally omitted from the table view.

## Validation

- `uv run pytest -v`
- `make lint`
