### PR TITLE
feat(summary): add retained receiver summary topic

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,12 @@ Configure the offline timeout used by retained status topics and table status:
 mtr2mqtt --offline-timeout 1800
 ```
 
+Configure the retained receiver summary debounce interval:
+
+```sh
+mtr2mqtt --summary-debounce-seconds 5
+```
+
 Use the live table view:
 
 ```sh
@@ -237,6 +243,58 @@ An entity is `online` after it has been observed at least once and the last vali
 Status topics are retained so downstream tooling can evaluate current receiver and sensor availability immediately after subscribing. Numeric `status_code` values are intended for simple alert conditions in tools such as `tvallas/mqtt-alerts`.
 
 Never-seen sensors are not fabricated at startup and do not publish offline status. Measurement topics and payloads are intentionally left untouched when a receiver or sensor goes offline: mtr2mqtt does not publish synthetic `null`, `0`, `"offline"`, or any other fake reading to `measurements/...`.
+
+### Receiver Summary Topics
+
+mtr2mqtt also publishes a compact retained receiver-level summary document:
+
+```text
+summary/<receiver_serial_number>
+```
+
+The summary topic is an additive materialized view for dashboards, operators, and simple consumers that want the latest values for one receiver without subscribing to every `measurements/<receiver_serial_number>/<sensor_id>` topic and merging state themselves. It does not replace measurement topics or status topics, and those existing topic payloads remain unchanged.
+
+Summary example:
+
+```json
+{
+  "receiver": "receiver-a",
+  "updated_at": "2026-04-26T12:00:00Z",
+  "transmitters": {
+    "sensor-101": {
+      "value": 21.4,
+      "measured_at": "2026-04-26T11:58:12Z",
+      "status": "online",
+      "status_code": 1,
+      "location": "Technical room",
+      "description": "Floor heating input",
+      "unit": "°C",
+      "quantity": "Temperature",
+      "zone": "Heating"
+    }
+  }
+}
+```
+
+Top-level fields:
+
+- `receiver`: receiver identifier
+- `updated_at`: UTC timestamp for the summary publish
+- `transmitters`: map of observed transmitter ids to compact latest state
+
+Each transmitter entry includes:
+
+- `value`: latest real measurement value from the measurement `reading`
+- `measured_at`: timestamp of that real measurement
+- `status`: current transmitter availability from the status tracker
+- `status_code`: `online` = `1`, `offline` = `0`
+- `location`, `description`, `unit`, `quantity`, and `zone` when available in metadata
+
+The summary intentionally includes only the selected metadata fields that help interpret the value directly. It does not mirror the full metadata model, the Home Assistant metadata block, or arbitrary internal fields.
+
+Only transmitters seen at least once are included. If a transmitter later goes offline, it remains in the summary with its last real `value` and `measured_at`; freshness is represented by `status` and `status_code`. mtr2mqtt does not publish synthetic offline readings or clear the last value.
+
+Summary messages are retained so new subscribers immediately receive the latest receiver snapshot. Summary publishing is coalesced per receiver with `--summary-debounce-seconds` or `MTR2MQTT_SUMMARY_DEBOUNCE_SECONDS`, defaulting to 5 seconds. Incoming measurements and status changes update in-memory state immediately, but full summary publishes are delayed so multiple rapid updates produce one retained summary publish instead of a full document on every reading.
 
 ### Home Assistant MQTT Discovery
 

--- a/mtr2mqtt/cli.py
+++ b/mtr2mqtt/cli.py
@@ -14,6 +14,7 @@ import serial
 from mtr2mqtt import homeassistant
 from mtr2mqtt.logging_utils import configure_root_logger
 from mtr2mqtt import metadata
+from mtr2mqtt import summary
 from mtr2mqtt.runtime import BridgeError
 from mtr2mqtt.runtime import MtrBridge
 
@@ -112,6 +113,17 @@ def create_parser():
         help="Seconds before observed receivers or sensors are marked offline "
         "(ENV: MTR2MQTT_OFFLINE_TIMEOUT)",
         default=_env_int("MTR2MQTT_OFFLINE_TIMEOUT", 30 * 60),
+        required=False,
+        type=int,
+    )
+    parser.add_argument(
+        "--summary-debounce-seconds",
+        help="Seconds to coalesce receiver summary publishes "
+        "(ENV: MTR2MQTT_SUMMARY_DEBOUNCE_SECONDS)",
+        default=_env_int(
+            "MTR2MQTT_SUMMARY_DEBOUNCE_SECONDS",
+            summary.DEFAULT_DEBOUNCE_SECONDS,
+        ),
         required=False,
         type=int,
     )

--- a/mtr2mqtt/runtime.py
+++ b/mtr2mqtt/runtime.py
@@ -19,6 +19,7 @@ from mtr2mqtt import homeassistant
 from mtr2mqtt import mtr
 from mtr2mqtt import scl
 from mtr2mqtt import status
+from mtr2mqtt import summary
 from mtr2mqtt.table_view import MeasurementTableView
 
 
@@ -433,6 +434,32 @@ def publish_status(mqtt_client, topic, payload):
     return result, mid
 
 
+def publish_summary(mqtt_client, receiver, payload):
+    """
+    Publish a retained receiver summary payload.
+    """
+    topic = summary.summary_topic(receiver)
+    if not getattr(mqtt_client, "connected_flag", True):
+        logging.warning(
+            "Skipping summary publish for %s because MQTT is disconnected",
+            topic,
+        )
+        return mqtt.MQTT_ERR_NO_CONN, None
+
+    try:
+        result, mid = mqtt_client.publish(
+            topic,
+            payload=json.dumps(payload, sort_keys=True),
+            qos=1,
+            retain=True,
+        )
+    except (OSError, RuntimeError, TypeError, ValueError):
+        logging.exception("Publishing summary failed for topic %s", topic)
+        return mqtt.MQTT_ERR_NO_CONN, None
+    logging.debug("summary publish result: %s, mid: %s", result, mid)
+    return result, mid
+
+
 class MtrBridge:  # pylint: disable=too-many-instance-attributes
     """
     Long-running runtime for polling an MTR receiver and publishing to MQTT.
@@ -448,6 +475,13 @@ class MtrBridge:  # pylint: disable=too-many-instance-attributes
         self.output_view = self._create_output_view()
         self.status_tracker = status.StatusTracker(
             offline_timeout=getattr(self.args, "offline_timeout", 30 * 60),
+        )
+        self.summary_tracker = summary.SummaryTracker(
+            debounce_seconds=getattr(
+                self.args,
+                "summary_debounce_seconds",
+                summary.DEFAULT_DEBOUNCE_SECONDS,
+            ),
         )
         self._last_status_sweep = 0
 
@@ -582,6 +616,7 @@ class MtrBridge:  # pylint: disable=too-many-instance-attributes
 
         published = []
         for key, payload, rendered in self.status_tracker.changed_payloads(now):
+            self.summary_tracker.record_status(payload)
             result, mid = publish_status(
                 self.mqtt_client,
                 self._status_topic(payload),
@@ -589,6 +624,23 @@ class MtrBridge:  # pylint: disable=too-many-instance-attributes
             )
             if result == mqtt.MQTT_ERR_SUCCESS:
                 self.status_tracker.mark_status_published(key, rendered)
+                published.append((payload, mid))
+        return published
+
+    def publish_due_summaries(self, now=None):
+        """
+        Publish retained receiver summaries whose debounce interval has elapsed.
+        """
+        if self.mqtt_client is None:
+            return []
+
+        published = []
+        for receiver, payload, rendered in self.summary_tracker.due_payloads(
+            updated_at=now,
+        ):
+            result, mid = publish_summary(self.mqtt_client, receiver, payload)
+            if result == mqtt.MQTT_ERR_SUCCESS:
+                self.summary_tracker.mark_published(receiver, rendered)
                 published.append((payload, mid))
         return published
 
@@ -605,6 +657,7 @@ class MtrBridge:  # pylint: disable=too-many-instance-attributes
         published = self.publish_status_changes(now)
         if self.output_view is not None:
             self.output_view.update_statuses(self.status_tracker.sensor_payloads(now))
+        self.publish_due_summaries(now)
         return published
 
     def run_forever(self):
@@ -615,6 +668,7 @@ class MtrBridge:  # pylint: disable=too-many-instance-attributes
         try:
             while True:
                 self.sweep_status()
+                self.publish_due_summaries()
                 poll_result = self.poll_once()
                 if poll_result.measurement_json:
                     measurement = json.loads(poll_result.measurement_json)
@@ -638,6 +692,15 @@ class MtrBridge:  # pylint: disable=too-many-instance-attributes
                         )
                     else:
                         log_measurement(poll_result.measurement_json)
+                    self.summary_tracker.record_measurement(
+                        receiver_serial_number,
+                        measurement,
+                        self.status_tracker.sensor_payload(
+                            receiver_serial_number,
+                            sensor_id,
+                            now,
+                        ),
+                    )
                     result, _mid = self.publish_measurement(poll_result.measurement_json)
                     if result == mqtt.MQTT_ERR_SUCCESS:
                         self.status_tracker.record_publish_success(
@@ -651,6 +714,7 @@ class MtrBridge:  # pylint: disable=too-many-instance-attributes
                             sensor_id,
                         )
                     self.publish_status_changes()
+                    self.publish_due_summaries()
                     continue
                 if poll_result.state in {
                     BridgeState.IDLE,

--- a/mtr2mqtt/summary.py
+++ b/mtr2mqtt/summary.py
@@ -1,0 +1,179 @@
+"""
+Receiver-level latest-value summary tracking.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+import json
+import time
+
+from mtr2mqtt import status as status_module
+
+
+SUMMARY_TOPIC_PREFIX = "summary"
+DEFAULT_DEBOUNCE_SECONDS = 5
+SUMMARY_METADATA_FIELDS = ("location", "description", "unit", "quantity", "zone")
+
+
+def summary_topic(receiver, prefix=SUMMARY_TOPIC_PREFIX):
+    """
+    Build the retained receiver summary topic.
+    """
+    return f"{prefix}/{receiver}"
+
+
+def _measurement_timestamp(measurement):
+    timestamp = measurement.get("timestamp")
+    if timestamp is None:
+        return None
+    try:
+        normalized = str(timestamp).replace("Z", "+00:00")
+        return status_module.format_timestamp(
+            datetime.fromisoformat(normalized),
+        )
+    except ValueError:
+        return str(timestamp)
+
+
+@dataclass
+class TransmitterSummary:
+    """
+    Compact latest state for one observed transmitter.
+    """
+
+    value: object = None
+    measured_at: str | None = None
+    status: str | None = None
+    status_code: int | None = None
+    metadata: dict | None = None
+
+    def payload(self):
+        """
+        Serialize the transmitter state as a compact MQTT summary entry.
+        """
+        data = {
+            "value": self.value,
+            "measured_at": self.measured_at,
+            "status": self.status,
+            "status_code": self.status_code,
+        }
+        if self.metadata:
+            data.update(self.metadata)
+        return data
+
+
+class SummaryTracker:
+    """
+    Track receiver summaries and coalesce retained MQTT publishes.
+    """
+
+    def __init__(self, debounce_seconds=DEFAULT_DEBOUNCE_SECONDS, monotonic=None):
+        self.debounce_seconds = debounce_seconds
+        self._monotonic = monotonic or time.monotonic
+        self.transmitters = {}
+        self._publish_due_at = {}
+        self._last_rendered = {}
+
+    def record_measurement(self, receiver, measurement, status_payload=None):
+        """
+        Record a real measurement and mark the receiver summary dirty if changed.
+        """
+        receiver = str(receiver)
+        sensor = str(measurement["id"])
+        key = (receiver, sensor)
+        metadata = {
+            field: measurement[field]
+            for field in SUMMARY_METADATA_FIELDS
+            if field in measurement
+        }
+        current = self.transmitters.get(key)
+        updated = TransmitterSummary(
+            value=measurement.get("reading"),
+            measured_at=_measurement_timestamp(measurement),
+            status=(
+                status_payload.get("status")
+                if status_payload
+                else status_module.STATUS_ONLINE
+            ),
+            status_code=(
+                status_payload.get("status_code")
+                if status_payload
+                else status_module.STATUS_CODES[status_module.STATUS_ONLINE]
+            ),
+            metadata=metadata,
+        )
+        if current != updated:
+            self.transmitters[key] = updated
+            self._mark_dirty(receiver)
+
+    def record_status(self, status_payload):
+        """
+        Update summary availability for an already observed transmitter.
+        """
+        if status_payload.get("entity_type") != "sensor":
+            return
+
+        receiver = str(status_payload["receiver"])
+        sensor = str(status_payload["sensor"])
+        key = (receiver, sensor)
+        current = self.transmitters.get(key)
+        if current is None:
+            return
+
+        if (
+            current.status == status_payload.get("status")
+            and current.status_code == status_payload.get("status_code")
+        ):
+            return
+
+        current.status = status_payload.get("status")
+        current.status_code = status_payload.get("status_code")
+        self._mark_dirty(receiver)
+
+    def due_payloads(self, now=None, updated_at=None):
+        """
+        Return receiver summary payloads whose debounce interval has elapsed.
+        """
+        now = self._monotonic() if now is None else now
+        updated_at = updated_at or status_module.utc_now()
+        due = []
+        for receiver, due_at in sorted(self._publish_due_at.items()):
+            if now < due_at:
+                continue
+            payload = self.payload(receiver, updated_at)
+            rendered = json.dumps(payload, sort_keys=True, separators=(",", ":"))
+            if rendered != self._last_rendered.get(receiver):
+                due.append((receiver, payload, rendered))
+        return due
+
+    def mark_published(self, receiver, rendered_payload):
+        """
+        Mark a summary payload as successfully published.
+        """
+        receiver = str(receiver)
+        self._last_rendered[receiver] = rendered_payload
+        self._publish_due_at.pop(receiver, None)
+
+    def payload(self, receiver, updated_at=None):
+        """
+        Build the current compact summary payload for one receiver.
+        """
+        receiver = str(receiver)
+        updated_at = updated_at or status_module.utc_now()
+        transmitters = {
+            sensor: summary.payload()
+            for (entry_receiver, sensor), summary in sorted(self.transmitters.items())
+            if entry_receiver == receiver
+        }
+        return {
+            "receiver": receiver,
+            "updated_at": status_module.format_timestamp(updated_at),
+            "transmitters": transmitters,
+        }
+
+    def _mark_dirty(self, receiver):
+        receiver = str(receiver)
+        if receiver not in self._publish_due_at:
+            self._publish_due_at[receiver] = self._monotonic() + self.debounce_seconds

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -36,6 +36,7 @@ def test_parser_defaults_without_arguments(monkeypatch):
     monkeypatch.delenv("MTR2MQTT_BAUDRATE", raising=False)
     monkeypatch.delenv("MTR2MQTT_SERIAL_TIMEOUT", raising=False)
     monkeypatch.delenv("MTR2MQTT_OFFLINE_TIMEOUT", raising=False)
+    monkeypatch.delenv("MTR2MQTT_SUMMARY_DEBOUNCE_SECONDS", raising=False)
     monkeypatch.delenv("MTR2MQTT_SCL_ADDRESS", raising=False)
     monkeypatch.delenv("MTR2MQTT_MQTT_HOST", raising=False)
     monkeypatch.delenv("MTR2MQTT_MQTT_PORT", raising=False)
@@ -55,6 +56,7 @@ def test_parser_defaults_without_arguments(monkeypatch):
     assert args.baudrate == 9600
     assert args.serial_timeout == 1
     assert args.offline_timeout == 1800
+    assert args.summary_debounce_seconds == 5
     assert args.scl_address == 126
     assert args.mqtt_host is None
     assert args.mqtt_port == 1883
@@ -77,6 +79,7 @@ def test_parser_reads_environment_defaults(monkeypatch):
     monkeypatch.setenv("MTR2MQTT_BAUDRATE", "115200")
     monkeypatch.setenv("MTR2MQTT_SERIAL_TIMEOUT", "5")
     monkeypatch.setenv("MTR2MQTT_OFFLINE_TIMEOUT", "120")
+    monkeypatch.setenv("MTR2MQTT_SUMMARY_DEBOUNCE_SECONDS", "7")
     monkeypatch.setenv("MTR2MQTT_SCL_ADDRESS", "1")
     monkeypatch.setenv("MTR2MQTT_MQTT_HOST", "mqtt.example")
     monkeypatch.setenv("MTR2MQTT_MQTT_PORT", "1884")
@@ -96,6 +99,7 @@ def test_parser_reads_environment_defaults(monkeypatch):
     assert args.baudrate == 115200
     assert args.serial_timeout == 5
     assert args.offline_timeout == 120
+    assert args.summary_debounce_seconds == 7
     assert args.scl_address == 1
     assert args.mqtt_host == "mqtt.example"
     assert args.mqtt_port == 1884

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -477,6 +477,43 @@ def test_publish_status_uses_retained_status_topic_payload():
     assert json.loads(client.calls[0][1]["payload"]) == payload
 
 
+def test_publish_summary_uses_retained_receiver_summary_topic():
+    """
+    Summary publishing is retained and separate from measurements and status.
+    """
+
+    class FakeClient:
+        def __init__(self):
+            self.calls = []
+
+        def publish(self, topic, **kwargs):
+            self.calls.append((topic, kwargs))
+            return (0, 1)
+
+    client = FakeClient()
+    payload = {
+        "receiver": "RTR970123",
+        "updated_at": "2026-04-26T12:00:00Z",
+        "transmitters": {
+            "15006": {
+                "value": 22.9,
+                "measured_at": "2026-04-26T10:15:32Z",
+                "status": "online",
+                "status_code": 1,
+            },
+        },
+    }
+
+    result, mid = runtime.publish_summary(client, "RTR970123", payload)
+
+    assert result == 0
+    assert mid == 1
+    assert client.calls[0][0] == "summary/RTR970123"
+    assert client.calls[0][1]["qos"] == 1
+    assert client.calls[0][1]["retain"] is True
+    assert json.loads(client.calls[0][1]["payload"]) == payload
+
+
 def test_bridge_publishes_measurement_unchanged_and_retained_status(monkeypatch):
     """
     Bridge status publishing is additive and does not alter measurement payloads.
@@ -528,6 +565,159 @@ def test_bridge_publishes_measurement_unchanged_and_retained_status(monkeypatch)
         payload = json.loads(kwargs["payload"])
         assert payload["status"] == "online"
         assert payload["status_code"] == 1
+
+
+def test_bridge_coalesces_summary_publish_without_changing_existing_topics():
+    """
+    Rapid measurement updates become one retained summary after debounce.
+    """
+
+    class FakeClient:
+        def __init__(self):
+            self.calls = []
+
+        def publish(self, topic, **kwargs):
+            self.calls.append((topic, kwargs))
+            return (0, len(self.calls))
+
+    measurement_one = {
+        "id": "15006",
+        "reading": 22.9,
+        "timestamp": "2026-04-26T10:15:32Z",
+        "location": "Technical room",
+        "description": "Floor heating input",
+        "unit": "°C",
+        "quantity": "Temperature",
+        "zone": "Heating",
+    }
+    measurement_two = {
+        "id": "15007",
+        "reading": 48.1,
+        "timestamp": "2026-04-26T10:15:33Z",
+    }
+    bridge = runtime.MtrBridge(
+        SimpleNamespace(
+            scl_address=126,
+            offline_timeout=1800,
+            summary_debounce_seconds=5,
+        )
+    )
+    bridge.receiver = runtime.ReceiverConnection(
+        serial_handle=SimpleNamespace(),
+        device_type="RTR970",
+        receiver_serial_number="RTR970123",
+        serial_config={},
+    )
+    bridge.mqtt_client = FakeClient()
+    receiver = bridge.receiver.receiver_serial_number
+
+    bridge.summary_tracker._monotonic = lambda: 0
+    for measurement in [measurement_one, measurement_two]:
+        bridge.status_tracker.record_observation(
+            receiver,
+            measurement["id"],
+            datetime(2026, 4, 26, 10, 15, 33, tzinfo=timezone.utc),
+        )
+        bridge.summary_tracker.record_measurement(
+            receiver,
+            measurement,
+            bridge.status_tracker.sensor_payload(
+                receiver,
+                measurement["id"],
+                datetime(2026, 4, 26, 10, 15, 33, tzinfo=timezone.utc),
+            ),
+        )
+        bridge.publish_measurement(json.dumps(measurement))
+        bridge.publish_due_summaries(
+            datetime(2026, 4, 26, 10, 15, 34, tzinfo=timezone.utc),
+        )
+
+    assert [topic for topic, _kwargs in bridge.mqtt_client.calls] == [
+        "measurements/RTR970123/15006",
+        "measurements/RTR970123/15007",
+    ]
+
+    bridge.summary_tracker._monotonic = lambda: 5
+    bridge.publish_due_summaries(
+        datetime(2026, 4, 26, 10, 15, 38, tzinfo=timezone.utc),
+    )
+
+    assert [topic for topic, _kwargs in bridge.mqtt_client.calls] == [
+        "measurements/RTR970123/15006",
+        "measurements/RTR970123/15007",
+        "summary/RTR970123",
+    ]
+    summary_payload = json.loads(bridge.mqtt_client.calls[-1][1]["payload"])
+    assert bridge.mqtt_client.calls[-1][1]["retain"] is True
+    assert set(summary_payload["transmitters"]) == {"15006", "15007"}
+    assert summary_payload["transmitters"]["15006"]["value"] == 22.9
+    assert summary_payload["transmitters"]["15006"]["status"] == "online"
+    assert summary_payload["transmitters"]["15006"]["status_code"] == 1
+    assert summary_payload["transmitters"]["15006"]["location"] == "Technical room"
+
+
+def test_bridge_summary_updates_status_to_offline_without_clearing_value():
+    """
+    Offline status transitions update summary availability only.
+    """
+
+    class FakeClient:
+        def __init__(self):
+            self.calls = []
+
+        def publish(self, topic, **kwargs):
+            self.calls.append((topic, kwargs))
+            return (0, len(self.calls))
+
+    bridge = runtime.MtrBridge(
+        SimpleNamespace(
+            scl_address=126,
+            offline_timeout=60,
+            summary_debounce_seconds=5,
+        )
+    )
+    bridge.receiver = runtime.ReceiverConnection(
+        serial_handle=SimpleNamespace(),
+        device_type="RTR970",
+        receiver_serial_number="RTR970123",
+        serial_config={},
+    )
+    bridge.mqtt_client = FakeClient()
+    receiver = bridge.receiver.receiver_serial_number
+    observed_at = datetime(2026, 4, 26, 10, 15, 32, tzinfo=timezone.utc)
+    offline_at = datetime(2026, 4, 26, 10, 16, 33, tzinfo=timezone.utc)
+
+    bridge.summary_tracker._monotonic = lambda: 0
+    bridge.status_tracker.record_observation(receiver, "15006", observed_at)
+    bridge.summary_tracker.record_measurement(
+        receiver,
+        {
+            "id": "15006",
+            "reading": 22.9,
+            "timestamp": "2026-04-26T10:15:32Z",
+        },
+        bridge.status_tracker.sensor_payload(receiver, "15006", observed_at),
+    )
+    bridge.publish_status_changes(observed_at)
+    bridge.summary_tracker._monotonic = lambda: 5
+    bridge.publish_due_summaries(observed_at)
+
+    bridge.summary_tracker._monotonic = lambda: 10
+    bridge.publish_status_changes(offline_at)
+    bridge.summary_tracker._monotonic = lambda: 15
+    bridge.publish_due_summaries(offline_at)
+
+    summary_payloads = [
+        json.loads(kwargs["payload"])
+        for topic, kwargs in bridge.mqtt_client.calls
+        if topic == "summary/RTR970123"
+    ]
+    assert len(summary_payloads) == 2
+    entry = summary_payloads[-1]["transmitters"]["15006"]
+    assert entry["value"] == 22.9
+    assert entry["measured_at"] == "2026-04-26T10:15:32Z"
+    assert entry["status"] == "offline"
+    assert entry["status_code"] == 0
 
 
 def test_log_measurement_adds_structured_measurement_payload(caplog):

--- a/tests/test_summary.py
+++ b/tests/test_summary.py
@@ -1,0 +1,169 @@
+"""
+Tests for receiver summary tracking.
+"""
+
+from datetime import datetime
+from datetime import timezone
+import json
+
+from context import mtr2mqtt
+from mtr2mqtt import summary
+
+
+def test_summary_topic_uses_receiver_namespace():
+    """
+    Summary topics are receiver-level topics.
+    """
+    assert summary.summary_topic("receiver-a") == "summary/receiver-a"
+
+
+def test_summary_payload_contains_known_transmitters_and_selected_metadata():
+    """
+    Summary payloads include compact latest transmitter state.
+    """
+    tracker = summary.SummaryTracker(debounce_seconds=5, monotonic=lambda: 0)
+
+    tracker.record_measurement(
+        "receiver-a",
+        {
+            "id": "sensor-101",
+            "reading": 21.4,
+            "timestamp": "2026-04-26T11:58:12Z",
+            "location": "Technical room",
+            "description": "Floor heating input",
+            "unit": "°C",
+            "quantity": "Temperature",
+            "zone": "Heating",
+            "ha": {"device_class": "temperature"},
+            "internal": "ignored",
+        },
+        {"status": "online", "status_code": 1},
+    )
+    tracker.record_measurement(
+        "receiver-a",
+        {
+            "id": "sensor-102",
+            "reading": 48.1,
+            "timestamp": "2026-04-26T11:55:01+00:00",
+            "location": "Boiler room",
+        },
+        {"status": "online", "status_code": 1},
+    )
+
+    payload = tracker.payload(
+        "receiver-a",
+        datetime(2026, 4, 26, 12, 0, 0, tzinfo=timezone.utc),
+    )
+
+    assert payload["receiver"] == "receiver-a"
+    assert payload["updated_at"] == "2026-04-26T12:00:00Z"
+    assert set(payload["transmitters"]) == {"sensor-101", "sensor-102"}
+    assert payload["transmitters"]["sensor-101"] == {
+        "value": 21.4,
+        "measured_at": "2026-04-26T11:58:12Z",
+        "status": "online",
+        "status_code": 1,
+        "location": "Technical room",
+        "description": "Floor heating input",
+        "unit": "°C",
+        "quantity": "Temperature",
+        "zone": "Heating",
+    }
+    assert "ha" not in payload["transmitters"]["sensor-101"]
+    assert "internal" not in payload["transmitters"]["sensor-101"]
+
+
+def test_offline_transmitter_keeps_last_real_value():
+    """
+    Offline status does not synthesize or clear the last measured value.
+    """
+    tracker = summary.SummaryTracker(debounce_seconds=5, monotonic=lambda: 0)
+    tracker.record_measurement(
+        "receiver-a",
+        {
+            "id": "sensor-101",
+            "reading": 21.4,
+            "timestamp": "2026-04-26T11:58:12Z",
+        },
+        {"status": "online", "status_code": 1},
+    )
+
+    tracker.record_status(
+        {
+            "entity_type": "sensor",
+            "receiver": "receiver-a",
+            "sensor": "sensor-101",
+            "status": "offline",
+            "status_code": 0,
+        },
+    )
+
+    entry = tracker.payload("receiver-a")["transmitters"]["sensor-101"]
+    assert entry["value"] == 21.4
+    assert entry["measured_at"] == "2026-04-26T11:58:12Z"
+    assert entry["status"] == "offline"
+    assert entry["status_code"] == 0
+
+
+def test_status_does_not_fabricate_never_seen_transmitters():
+    """
+    Summary state only includes transmitters observed through real measurements.
+    """
+    tracker = summary.SummaryTracker(debounce_seconds=5, monotonic=lambda: 0)
+
+    tracker.record_status(
+        {
+            "entity_type": "sensor",
+            "receiver": "receiver-a",
+            "sensor": "sensor-101",
+            "status": "offline",
+            "status_code": 0,
+        },
+    )
+
+    assert tracker.payload("receiver-a")["transmitters"] == {}
+
+
+def test_summary_publishes_are_coalesced_until_debounce_expires():
+    """
+    Multiple rapid measurements produce one due summary after the debounce interval.
+    """
+    monotonic_value = 0
+    tracker = summary.SummaryTracker(
+        debounce_seconds=5,
+        monotonic=lambda: monotonic_value,
+    )
+
+    tracker.record_measurement(
+        "receiver-a",
+        {
+            "id": "sensor-101",
+            "reading": 21.4,
+            "timestamp": "2026-04-26T11:58:12Z",
+        },
+    )
+    monotonic_value = 1
+    tracker.record_measurement(
+        "receiver-a",
+        {
+            "id": "sensor-102",
+            "reading": 48.1,
+            "timestamp": "2026-04-26T11:58:13Z",
+        },
+    )
+
+    assert tracker.due_payloads(now=4) == []
+
+    due = tracker.due_payloads(
+        now=5,
+        updated_at=datetime(2026, 4, 26, 12, 0, 0, tzinfo=timezone.utc),
+    )
+
+    assert len(due) == 1
+    receiver, payload, rendered = due[0]
+    assert receiver == "receiver-a"
+    assert set(payload["transmitters"]) == {"sensor-101", "sensor-102"}
+    assert json.loads(rendered) == payload
+
+    tracker.mark_published(receiver, rendered)
+    assert tracker.due_payloads(now=6) == []


### PR DESCRIPTION
## Summary

Adds a retained `summary/<receiver>` MQTT topic that publishes a compact receiver-level snapshot of all observed transmitters.

The summary includes each transmitter's latest real value, measured timestamp, current availability status, numeric status code, and selected interpretive metadata fields: `location`, `description`, `unit`, `quantity`, and `zone`.

## Why

The existing `measurements/<receiver>/<sensor>` topics remain the normalized per-sensor stream, but dashboards and simple consumers currently need to subscribe to many topics and maintain their own latest-value cache. `summary/<receiver>` provides a compact materialized view for receiver-level dashboards and operator tooling.

## Compatibility

This is additive only:

- existing measurement topics and payloads are unchanged
- existing status topics and payloads are unchanged
- users who do not subscribe to `summary/<receiver>` see no behavior change

## Design Notes

The summary intentionally includes only selected metadata needed to interpret the value directly. It does not mirror the full metadata model or Home Assistant metadata.

Summary publishing is debounced/coalesced per receiver, defaulting to 5 seconds, so bursts of transmitter updates produce one retained summary publish instead of republishing the full receiver document for every reading.

Offline transmitters remain present after being seen once. Their last real value and measured timestamp are preserved, while `status` and `status_code` reflect availability.

## Validation

- `uv run pytest`
- `make lint`
- `make test`
