### PR TITLE
feat(summary): include transmitter battery voltage

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,6 +263,7 @@ Summary example:
   "transmitters": {
     "sensor-101": {
       "value": 21.4,
+      "battery": 2.6,
       "measured_at": "2026-04-26T11:58:12Z",
       "status": "online",
       "status_code": 1,
@@ -285,6 +286,7 @@ Top-level fields:
 Each transmitter entry includes:
 
 - `value`: latest real measurement value from the measurement `reading`
+- `battery`: latest battery voltage when the transmitter reports it
 - `measured_at`: timestamp of that real measurement
 - `status`: current transmitter availability from the status tracker
 - `status_code`: `online` = `1`, `offline` = `0`

--- a/mtr2mqtt/summary.py
+++ b/mtr2mqtt/summary.py
@@ -44,6 +44,7 @@ class TransmitterSummary:
     """
 
     value: object = None
+    battery: object = None
     measured_at: str | None = None
     status: str | None = None
     status_code: int | None = None
@@ -59,6 +60,8 @@ class TransmitterSummary:
             "status": self.status,
             "status_code": self.status_code,
         }
+        if self.battery is not None:
+            data["battery"] = self.battery
         if self.metadata:
             data.update(self.metadata)
         return data
@@ -91,6 +94,7 @@ class SummaryTracker:
         current = self.transmitters.get(key)
         updated = TransmitterSummary(
             value=measurement.get("reading"),
+            battery=measurement.get("battery"),
             measured_at=_measurement_timestamp(measurement),
             status=(
                 status_payload.get("status")

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -497,6 +497,7 @@ def test_publish_summary_uses_retained_receiver_summary_topic():
         "transmitters": {
             "15006": {
                 "value": 22.9,
+                "battery": 2.6,
                 "measured_at": "2026-04-26T10:15:32Z",
                 "status": "online",
                 "status_code": 1,
@@ -583,6 +584,7 @@ def test_bridge_coalesces_summary_publish_without_changing_existing_topics():
     measurement_one = {
         "id": "15006",
         "reading": 22.9,
+        "battery": 2.6,
         "timestamp": "2026-04-26T10:15:32Z",
         "location": "Technical room",
         "description": "Floor heating input",
@@ -651,6 +653,7 @@ def test_bridge_coalesces_summary_publish_without_changing_existing_topics():
     assert bridge.mqtt_client.calls[-1][1]["retain"] is True
     assert set(summary_payload["transmitters"]) == {"15006", "15007"}
     assert summary_payload["transmitters"]["15006"]["value"] == 22.9
+    assert summary_payload["transmitters"]["15006"]["battery"] == 2.6
     assert summary_payload["transmitters"]["15006"]["status"] == "online"
     assert summary_payload["transmitters"]["15006"]["status_code"] == 1
     assert summary_payload["transmitters"]["15006"]["location"] == "Technical room"
@@ -694,6 +697,7 @@ def test_bridge_summary_updates_status_to_offline_without_clearing_value():
         {
             "id": "15006",
             "reading": 22.9,
+            "battery": 2.6,
             "timestamp": "2026-04-26T10:15:32Z",
         },
         bridge.status_tracker.sensor_payload(receiver, "15006", observed_at),
@@ -715,6 +719,7 @@ def test_bridge_summary_updates_status_to_offline_without_clearing_value():
     assert len(summary_payloads) == 2
     entry = summary_payloads[-1]["transmitters"]["15006"]
     assert entry["value"] == 22.9
+    assert entry["battery"] == 2.6
     assert entry["measured_at"] == "2026-04-26T10:15:32Z"
     assert entry["status"] == "offline"
     assert entry["status_code"] == 0

--- a/tests/test_summary.py
+++ b/tests/test_summary.py
@@ -28,6 +28,7 @@ def test_summary_payload_contains_known_transmitters_and_selected_metadata():
         {
             "id": "sensor-101",
             "reading": 21.4,
+            "battery": 2.6,
             "timestamp": "2026-04-26T11:58:12Z",
             "location": "Technical room",
             "description": "Floor heating input",
@@ -44,6 +45,7 @@ def test_summary_payload_contains_known_transmitters_and_selected_metadata():
         {
             "id": "sensor-102",
             "reading": 48.1,
+            "battery": 2.8,
             "timestamp": "2026-04-26T11:55:01+00:00",
             "location": "Boiler room",
         },
@@ -60,6 +62,7 @@ def test_summary_payload_contains_known_transmitters_and_selected_metadata():
     assert set(payload["transmitters"]) == {"sensor-101", "sensor-102"}
     assert payload["transmitters"]["sensor-101"] == {
         "value": 21.4,
+        "battery": 2.6,
         "measured_at": "2026-04-26T11:58:12Z",
         "status": "online",
         "status_code": 1,
@@ -83,6 +86,7 @@ def test_offline_transmitter_keeps_last_real_value():
         {
             "id": "sensor-101",
             "reading": 21.4,
+            "battery": 2.6,
             "timestamp": "2026-04-26T11:58:12Z",
         },
         {"status": "online", "status_code": 1},
@@ -100,9 +104,30 @@ def test_offline_transmitter_keeps_last_real_value():
 
     entry = tracker.payload("receiver-a")["transmitters"]["sensor-101"]
     assert entry["value"] == 21.4
+    assert entry["battery"] == 2.6
     assert entry["measured_at"] == "2026-04-26T11:58:12Z"
     assert entry["status"] == "offline"
     assert entry["status_code"] == 0
+
+
+def test_summary_omits_battery_when_measurement_has_no_battery_value():
+    """
+    Summary entries include battery only when the measurement provides it.
+    """
+    tracker = summary.SummaryTracker(debounce_seconds=5, monotonic=lambda: 0)
+
+    tracker.record_measurement(
+        "receiver-a",
+        {
+            "id": "sensor-101",
+            "reading": 21.4,
+            "timestamp": "2026-04-26T11:58:12Z",
+        },
+        {"status": "online", "status_code": 1},
+    )
+
+    entry = tracker.payload("receiver-a")["transmitters"]["sensor-101"]
+    assert "battery" not in entry
 
 
 def test_status_does_not_fabricate_never_seen_transmitters():


### PR DESCRIPTION
## Summary

Adds the latest reported transmitter `battery` value to each `summary/<receiver>` transmitter entry when the measurement payload provides it.

## Why

Battery voltage is operationally important and is easy to miss when consumers only look at the receiver-level summary. Including it in the compact summary helps dashboards and operators notice batteries that are running low without subscribing to every per-sensor measurement topic.

## Compatibility

This is additive only:

- existing measurement topics and payloads are unchanged
- existing status topics and payloads are unchanged
- summary entries without a reported battery value simply omit `battery`

## Design Notes

The summary continues to use the existing measurement payload as its source of truth. No thresholds or synthetic battery states are introduced in this PR; the summary exposes the latest reported battery voltage alongside the latest value, measured timestamp, availability, and selected metadata.

Offline transmitters keep their last real value and battery reading. Availability continues to be represented by `status` and `status_code`.

## Validation

- `uv run pytest`
- `make lint`
- `make test`
