### PR TITLE
fix(security): sanitize MQTT topic identifiers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,8 @@ RUN apk upgrade --no-cache
 
 COPY --from=builder /tmp/wheels /tmp/wheels
 
-RUN python -m pip install --no-cache-dir --no-compile /tmp/wheels/*.whl && \
+RUN python -m pip install --no-cache-dir --upgrade pip && \
+    python -m pip install --no-cache-dir --no-compile /tmp/wheels/*.whl && \
     rm -rf /tmp/wheels
 
 ENTRYPOINT ["mtr2mqtt"]

--- a/README.md
+++ b/README.md
@@ -167,7 +167,9 @@ Each sensor entry should include:
 - `description`: A descriptive label for the sensor.
 - `unit`: The unit of measurement for the sensor's readings.
 
-**Note:** Other metadata fields can be freely added and those are added to the JSON object.
+**Note:** Other metadata fields can be added and those are added to the JSON object,
+except for core measurement fields such as `battery`, `type`, `rsl`, `id`, `reading`,
+`timestamp`, `message`, `calibrated`, and `utility`.
 
 The optional `ha:` block is used only for Home Assistant discovery customization. It can override the main reading entity metadata with fields such as `name`, `device_class`, `state_class`, `suggested_display_precision`, and `icon`. Existing metadata files continue to work unchanged.
 
@@ -372,7 +374,9 @@ To align better with typical Home Assistant sensor setups, the primary reading e
 - `reading`: The current reading from the sensor.
 - `timestamp`: The timestamp of the reading in ISO 8601 format.
 
-**Note:** Other metadata fields can be freely added and those are added to the JSON object.
+**Note:** Other metadata fields can be added and those are added to the JSON object,
+except for core measurement fields such as `battery`, `type`, `rsl`, `id`, `reading`,
+`timestamp`, `message`, `calibrated`, and `utility`.
 
 ## Preparing the Development Environment
 

--- a/mtr2mqtt/homeassistant.py
+++ b/mtr2mqtt/homeassistant.py
@@ -9,6 +9,8 @@ import logging
 import re
 from importlib.metadata import PackageNotFoundError, version
 
+from mtr2mqtt.topics import topic_fragment
+
 
 def sanitize_id(value):
     """
@@ -22,7 +24,9 @@ def state_topic(receiver_serial_number, sensor_id):
     """
     Build the measurement state topic.
     """
-    return f"measurements/{receiver_serial_number}/{sensor_id}"
+    receiver = topic_fragment(receiver_serial_number)
+    sensor = topic_fragment(sensor_id)
+    return f"measurements/{receiver}/{sensor}"
 
 
 def device_identifier(sensor_id):

--- a/mtr2mqtt/mtr.py
+++ b/mtr2mqtt/mtr.py
@@ -16,6 +16,20 @@ from collections import namedtuple
 from collections import defaultdict
 from mtr2mqtt import metadata
 
+
+RESERVED_METADATA_FIELDS = frozenset({
+    "battery",
+    "type",
+    "rsl",
+    "id",
+    "reading",
+    "timestamp",
+    "message",
+    "calibrated",
+    "utility",
+})
+
+
 class TransmitterType(Enum):
     """ MTR series Transmitter types """
     FT10 = 0
@@ -72,7 +86,7 @@ def _get_header_fields(payload):
             battery_voltage = (
                 int(payload_fields[1]) & 31
             ) / 10  # clear 3 highest bits used for data length (31 = 00011111)
-            transmitter_id = str(payload_fields[3])
+            transmitter_id = str(int(payload_fields[3]))
             rsl = (int(payload_fields[2]) & 127) - 127
         except (IndexError, ValueError):
             logging.warning("Malformed payload header, skipping payload: %s", payload)
@@ -219,6 +233,11 @@ def mtr_response_to_json(payload, transmitters_metadata):
             )
             logging.debug("Transmitter info: %s", transmitter_information)
             if transmitter_information:
+                transmitter_information = {
+                    key: value
+                    for key, value in transmitter_information.items()
+                    if key not in RESERVED_METADATA_FIELDS
+                }
                 data_with_transmitter_info = {**data, **transmitter_information}
                 return json.dumps(data_with_transmitter_info)
         return json.dumps(data)

--- a/mtr2mqtt/status.py
+++ b/mtr2mqtt/status.py
@@ -9,6 +9,8 @@ from datetime import datetime
 from datetime import timezone
 import json
 
+from mtr2mqtt.topics import topic_fragment
+
 
 STATUS_TOPIC_PREFIX = "status"
 STATUS_ONLINE = "online"
@@ -42,14 +44,14 @@ def receiver_status_topic(receiver, prefix=STATUS_TOPIC_PREFIX):
     """
     Build the retained receiver status topic.
     """
-    return f"{prefix}/{receiver}"
+    return f"{prefix}/{topic_fragment(receiver)}"
 
 
 def sensor_status_topic(receiver, sensor, prefix=STATUS_TOPIC_PREFIX):
     """
     Build the retained sensor status topic.
     """
-    return f"{prefix}/{receiver}/{sensor}"
+    return f"{prefix}/{topic_fragment(receiver)}/{topic_fragment(sensor)}"
 
 
 @dataclass

--- a/mtr2mqtt/summary.py
+++ b/mtr2mqtt/summary.py
@@ -10,6 +10,7 @@ import json
 import time
 
 from mtr2mqtt import status as status_module
+from mtr2mqtt.topics import topic_fragment
 
 
 SUMMARY_TOPIC_PREFIX = "summary"
@@ -21,7 +22,7 @@ def summary_topic(receiver, prefix=SUMMARY_TOPIC_PREFIX):
     """
     Build the retained receiver summary topic.
     """
-    return f"{prefix}/{receiver}"
+    return f"{prefix}/{topic_fragment(receiver)}"
 
 
 def _measurement_timestamp(measurement):

--- a/mtr2mqtt/topics.py
+++ b/mtr2mqtt/topics.py
@@ -1,0 +1,13 @@
+"""
+MQTT topic helpers.
+"""
+
+import re
+
+
+def topic_fragment(value):
+    """
+    Return one MQTT-safe topic path fragment for an arbitrary identifier.
+    """
+    sanitized = re.sub(r"[^A-Za-z0-9_.-]+", "_", str(value).strip())
+    return sanitized.strip("_") or "unknown"

--- a/tests/test_dockerfile.py
+++ b/tests/test_dockerfile.py
@@ -1,0 +1,16 @@
+"""
+Tests for container build hardening.
+"""
+
+from pathlib import Path
+
+
+def test_final_image_upgrades_pip_before_installing_wheels():
+    """
+    The runtime image must not keep the vulnerable pip bundled with the base image.
+    """
+    dockerfile = Path("Dockerfile").read_text(encoding="utf-8")
+    final_stage = dockerfile.split("FROM python:3.14-alpine", maxsplit=2)[-1]
+
+    assert "python -m pip install --no-cache-dir --upgrade pip" in final_stage
+    assert final_stage.index("--upgrade pip") < final_stage.index("/tmp/wheels/*.whl")

--- a/tests/test_homeassistant.py
+++ b/tests/test_homeassistant.py
@@ -33,6 +33,16 @@ def test_discovery_topic_with_node_id():
     )
 
 
+def test_state_topic_sanitizes_receiver_and_sensor_fragments():
+    """
+    Measurement topics keep receiver and sensor ids within one topic level each.
+    """
+    assert (
+        homeassistant.state_topic("RTR/970+#", "15/006+#")
+        == "measurements/RTR_970/15_006"
+    )
+
+
 def test_build_discovery_payload_contains_expected_components():
     """
     Device discovery payloads include reading, battery, and rsl components.
@@ -73,6 +83,29 @@ def test_build_discovery_payload_contains_expected_components():
     assert payload["cmps"]["battery"]["value_template"] == "{{ value_json.battery }}"
     assert payload["cmps"]["rsl"]["name"] == "Signal"
     assert payload["cmps"]["rsl"]["value_template"] == "{{ value_json.rsl }}"
+
+
+def test_build_discovery_payload_uses_sanitized_state_topics():
+    """
+    Discovery payload state topics use sanitized receiver and sensor fragments.
+    """
+    measurement = {
+        "id": "15/006+#",
+        "type": "FT10",
+        "reading": 22.9,
+        "battery": 2.6,
+        "rsl": -69,
+    }
+
+    payload = json.loads(
+        homeassistant.build_discovery_payload("RTR/970+#", measurement)
+    )
+
+    assert payload["state_topic"] == "measurements/RTR_970/15_006"
+    assert (
+        payload["cmps"]["reading"]["json_attributes_topic"]
+        == "measurements/RTR_970/15_006"
+    )
 
 
 def test_build_discovery_payload_inferrs_temperature_fields():

--- a/tests/test_mtr.py
+++ b/tests/test_mtr.py
@@ -45,6 +45,7 @@ MTR_TOO_SHORT_INPUT = "0 90 58 15006"
 MTR_SIZE_MISMATCH_INPUT = "0 122 58 15006 145 11"
 MTR_CSR260_READING_INPUT = "11 90 58 15006 145 11"
 MTR_MALFORMED_LENGTH_INPUT = "0 xx 58 15006 145 11"
+MTR_MALFORMED_TRANSMITTER_ID_INPUT = "0 90 58 15/006 145 11"
 MTR_UNKNOWN_TYPE_INPUT = "99 90 58 15006 145 11"
 
 
@@ -157,6 +158,33 @@ def test_mtr_response_to_json_with_metadata_merge():
 
 
 @freeze_time("2020-09-23 19:34:13.497019+00:00")
+def test_mtr_response_to_json_ignores_metadata_for_reserved_measurement_fields():
+    """
+    Metadata must not override measured telemetry fields.
+    """
+    transmitters_metadata = json.dumps([
+        {
+            "id": 15006,
+            "reading": 999,
+            "battery": 9.9,
+            "type": "spoofed",
+            "timestamp": "spoofed",
+            "location": "Living room",
+        }
+    ])
+
+    assert json.loads(mtr.mtr_response_to_json(MTR_READING_INPUT, transmitters_metadata)) == {
+        "battery": 2.6,
+        "type": "FT10",
+        "rsl": -69,
+        "id": "15006",
+        "reading": 22.9,
+        "timestamp": "2020-09-23 19:34:13.497019+00:00",
+        "location": "Living room",
+    }
+
+
+@freeze_time("2020-09-23 19:34:13.497019+00:00")
 def test_mtr_response_to_json_with_missing_metadata_keeps_original_payload():
     """
     Missing transmitter metadata does not change the produced JSON.
@@ -225,6 +253,13 @@ def test_mtr_response_to_json_returns_none_for_malformed_message():
     Malformed payload fields are ignored instead of raising.
     """
     assert mtr.mtr_response_to_json(MTR_MALFORMED_LENGTH_INPUT, None) is None
+
+
+def test_mtr_response_to_json_returns_none_for_malformed_transmitter_id():
+    """
+    Non-numeric transmitter ids are rejected before they can reach MQTT topics.
+    """
+    assert mtr.mtr_response_to_json(MTR_MALFORMED_TRANSMITTER_ID_INPUT, None) is None
 
 
 def test_mtr_response_to_json_returns_none_for_unknown_transmitter_type():

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -438,6 +438,33 @@ def test_publish_measurement_without_discovery_keeps_normal_publish_behavior():
     ]
 
 
+def test_publish_measurement_sanitizes_topic_fragments():
+    """
+    Crafted receiver or sensor ids cannot publish outside the measurement namespace.
+    """
+
+    class FakeClient:
+        def __init__(self):
+            self.calls = []
+
+        def publish(self, topic, **kwargs):
+            self.calls.append((topic, kwargs))
+            return (0, 1)
+
+    client = FakeClient()
+
+    result, mid = runtime.publish_measurement(
+        client,
+        "RTR/970+#",
+        '{"id":"15/006+#","type":"FT10","reading":22.9,"battery":2.6,"rsl":-69}',
+        ha_discovery_publisher=None,
+    )
+
+    assert result == 0
+    assert mid == 1
+    assert client.calls[0][0] == "measurements/RTR_970/15_006"
+
+
 def test_publish_status_uses_retained_status_topic_payload():
     """
     Status publishing is retained and separate from measurement publishing.

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -124,6 +124,17 @@ def test_status_topics_are_separate_from_measurement_topics():
     )
 
 
+def test_status_topics_sanitize_receiver_and_sensor_fragments():
+    """
+    Status topic ids cannot add topic levels or MQTT wildcard characters.
+    """
+    assert status.receiver_status_topic("receiver/a+#") == "status/receiver_a"
+    assert (
+        status.sensor_status_topic("receiver/a+#", "sensor/123+#")
+        == "status/receiver_a/sensor_123"
+    )
+
+
 def test_never_seen_sensor_does_not_publish_offline_state():
     """
     The tracker only emits status payloads for observed entities.

--- a/tests/test_summary.py
+++ b/tests/test_summary.py
@@ -17,6 +17,13 @@ def test_summary_topic_uses_receiver_namespace():
     assert summary.summary_topic("receiver-a") == "summary/receiver-a"
 
 
+def test_summary_topic_sanitizes_receiver_fragment():
+    """
+    Summary topics keep the receiver id within one topic level.
+    """
+    assert summary.summary_topic("receiver/a+#") == "summary/receiver_a"
+
+
 def test_summary_payload_contains_known_transmitters_and_selected_metadata():
     """
     Summary payloads include compact latest transmitter state.


### PR DESCRIPTION
## Summary
- sanitize receiver and sensor identifiers before using them as MQTT topic fragments
- reject malformed non-numeric MTR transmitter ids before publishing
- keep metadata additive by preventing it from overriding reserved measured telemetry fields
- document the reserved metadata fields in the README

## Why
Crafted serial/runtime identifiers could add MQTT topic levels or wildcard characters when used in measurement, status, summary, and Home Assistant state topics. Metadata could also replace measured fields such as reading, battery, type, and timestamp, which weakens telemetry integrity.

## Validation
- uv run pytest
- make test
- make lint

## Limitations
No live serial receiver or MQTT broker integration was exercised locally.