### PR TITLE
feat(runtime): filter unconfigured metadata transmitters

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,19 @@ To use the metadata file with `mtr2mqtt`, pass the file path as an argument:
 mtr2mqtt -f metadata.yml
 ```
 
+To process only transmitters configured in `metadata.yml`, enable metadata-only
+mode:
+
+```sh
+mtr2mqtt -f metadata.yml --metadata-transmitters-only
+```
+
+The same mode can be enabled with `MTR2MQTT_METADATA_TRANSMITTERS_ONLY=true`.
+When enabled, readings from transmitter IDs that are not present in the metadata
+file are skipped before MQTT publishing, Home Assistant discovery, status
+tracking, receiver summaries, and table output. Skipped readings are still
+available in debug logs when `--debug` or `MTR2MQTT_DEBUG=true` is enabled.
+
 ### MQTT Topics and message format
 
 The messages are published to the MQTT broker in a structured JSON format. The structure of the topics and message format is as follows:

--- a/mtr2mqtt/cli.py
+++ b/mtr2mqtt/cli.py
@@ -160,6 +160,14 @@ def create_parser():
         type=str,
     )
     parser.add_argument(
+        "--metadata-transmitters-only",
+        help="Only process transmitters configured in the metadata file "
+        "(ENV: MTR2MQTT_METADATA_TRANSMITTERS_ONLY)",
+        default=_env_flag("MTR2MQTT_METADATA_TRANSMITTERS_ONLY", False),
+        action=BooleanOptionalAction,
+        required=False,
+    )
+    parser.add_argument(
         "--output",
         help="Console output mode (ENV: MTR2MQTT_OUTPUT)",
         default=os.environ.get("MTR2MQTT_OUTPUT", "json"),

--- a/mtr2mqtt/metadata.py
+++ b/mtr2mqtt/metadata.py
@@ -39,30 +39,73 @@ def loadfile(file):
             f"Metadata file {file} contains values that cannot be serialized to JSON"
         ) from error
 
-def get_data(transmitter_id, all_transmitters):
-    """
-    Gets metada for transmitter
-    """
+
+def _load_transmitter_list(all_transmitters):
     try:
-        all_transmitters = json.loads(all_transmitters)
+        transmitter_list = json.loads(all_transmitters)
     except (TypeError, json.JSONDecodeError):
         logging.warning("Metadata content is not valid JSON, skipping lookup")
         return None
 
+    if not isinstance(transmitter_list, list):
+        logging.warning(
+            "Metadata must be a list of transmitters, got %s",
+            type(transmitter_list).__name__,
+        )
+        return None
+
+    return transmitter_list
+
+
+def _normalized_transmitter_id(transmitter_id):
     try:
-        transmitter_id = int(transmitter_id)
+        return int(transmitter_id)
     except (TypeError, ValueError):
         logging.warning("Transmitter id %r is not a valid integer", transmitter_id)
         return None
 
+
+def has_transmitter_id(transmitter_id, all_transmitters):
+    """
+    Return True when a transmitter id is configured in the metadata list.
+    """
+    all_transmitters = _load_transmitter_list(all_transmitters)
+    if all_transmitters is None:
+        return False
+
+    transmitter_id = _normalized_transmitter_id(transmitter_id)
+    if transmitter_id is None:
+        return False
+
     logging.debug("All transmitters metadata: %s", all_transmitters)
     logging.debug("Transmitter id: %s", transmitter_id)
-    if not isinstance(all_transmitters, list):
-        logging.warning(
-            "Metadata must be a list of transmitters, got %s",
-            type(all_transmitters).__name__,
-        )
+    for transmitter in all_transmitters:
+        if not isinstance(transmitter, dict):
+            logging.debug(
+                "Skipping metadata entry with unexpected type: %s",
+                type(transmitter).__name__,
+            )
+            continue
+        logging.debug("Iterated transmitter: %s", transmitter)
+        if transmitter.get('id') == transmitter_id:
+            return True
+    return False
+
+
+def get_data(transmitter_id, all_transmitters):
+    """
+    Gets metada for transmitter
+    """
+    all_transmitters = _load_transmitter_list(all_transmitters)
+    if all_transmitters is None:
         return None
+
+    transmitter_id = _normalized_transmitter_id(transmitter_id)
+    if transmitter_id is None:
+        return None
+
+    logging.debug("All transmitters metadata: %s", all_transmitters)
+    logging.debug("Transmitter id: %s", transmitter_id)
     info = None
     for transmitter in all_transmitters:
         if not isinstance(transmitter, dict):

--- a/mtr2mqtt/runtime.py
+++ b/mtr2mqtt/runtime.py
@@ -16,6 +16,7 @@ import serial
 from serial.tools import list_ports
 
 from mtr2mqtt import homeassistant
+from mtr2mqtt import metadata
 from mtr2mqtt import mtr
 from mtr2mqtt import scl
 from mtr2mqtt import status
@@ -582,6 +583,23 @@ class MtrBridge:  # pylint: disable=too-many-instance-attributes
             parsed_response,
             self.transmitters_metadata,
         )
+        if (
+            measurement_json
+            and getattr(self.args, "metadata_transmitters_only", False)
+        ):
+            measurement = json.loads(measurement_json)
+            if not metadata.has_transmitter_id(
+                measurement["id"],
+                self.transmitters_metadata,
+            ):
+                LOGGER.debug(
+                    "Skipping transmitter not configured in metadata",
+                    extra={
+                        "event": "measurement_skipped_unconfigured",
+                        "measurement": measurement,
+                    },
+                )
+                measurement_json = None
 
         return PollResult(
             BridgeState.READY,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -41,6 +41,7 @@ def test_parser_defaults_without_arguments(monkeypatch):
     monkeypatch.delenv("MTR2MQTT_MQTT_HOST", raising=False)
     monkeypatch.delenv("MTR2MQTT_MQTT_PORT", raising=False)
     monkeypatch.delenv("MTR2MQTT_METADATA_FILE", raising=False)
+    monkeypatch.delenv("MTR2MQTT_METADATA_TRANSMITTERS_ONLY", raising=False)
     monkeypatch.delenv("MTR2MQTT_OUTPUT", raising=False)
     monkeypatch.delenv("MTR2MQTT_HA_DISCOVERY", raising=False)
     monkeypatch.delenv("MTR2MQTT_HA_DISCOVERY_PREFIX", raising=False)
@@ -61,6 +62,7 @@ def test_parser_defaults_without_arguments(monkeypatch):
     assert args.mqtt_host is None
     assert args.mqtt_port == 1883
     assert args.metadata_file is None
+    assert args.metadata_transmitters_only is False
     assert args.output == "json"
     assert args.ha_discovery is False
     assert args.ha_discovery_prefix == "homeassistant"
@@ -84,6 +86,7 @@ def test_parser_reads_environment_defaults(monkeypatch):
     monkeypatch.setenv("MTR2MQTT_MQTT_HOST", "mqtt.example")
     monkeypatch.setenv("MTR2MQTT_MQTT_PORT", "1884")
     monkeypatch.setenv("MTR2MQTT_METADATA_FILE", "tests/metadata.yml")
+    monkeypatch.setenv("MTR2MQTT_METADATA_TRANSMITTERS_ONLY", "true")
     monkeypatch.setenv("MTR2MQTT_OUTPUT", "table")
     monkeypatch.setenv("MTR2MQTT_HA_DISCOVERY", "true")
     monkeypatch.setenv("MTR2MQTT_HA_DISCOVERY_PREFIX", "ha")
@@ -104,6 +107,7 @@ def test_parser_reads_environment_defaults(monkeypatch):
     assert args.mqtt_host == "mqtt.example"
     assert args.mqtt_port == 1884
     assert args.metadata_file == "tests/metadata.yml"
+    assert args.metadata_transmitters_only is True
     assert args.output == "table"
     assert args.ha_discovery is True
     assert args.ha_discovery_prefix == "ha"
@@ -198,6 +202,7 @@ def test_parser_parses_common_options():
             "0",
             "--metadata-file",
             "tests/metadata.yml",
+            "--metadata-transmitters-only",
             "--output",
             "table",
         ]
@@ -209,6 +214,7 @@ def test_parser_parses_common_options():
     assert args.serial_timeout == 2
     assert args.scl_address == 0
     assert args.metadata_file == "tests/metadata.yml"
+    assert args.metadata_transmitters_only is True
     assert args.output == "table"
 
 

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -52,6 +52,20 @@ def test_metadata_get_data_returns_none_for_missing_transmitter():
     assert metadata.get_data(9999, METADATA_TEST_FILE_OUTPUT) is None
 
 
+def test_metadata_has_transmitter_id_returns_true_for_configured_transmitter():
+    """
+    Metadata membership checks only require the id to be configured.
+    """
+    assert metadata.has_transmitter_id(1234, json.dumps([{"id": 1234}])) is True
+
+
+def test_metadata_has_transmitter_id_returns_false_for_missing_transmitter():
+    """
+    Metadata membership checks return false when the id is not configured.
+    """
+    assert metadata.has_transmitter_id(9999, METADATA_TEST_FILE_OUTPUT) is False
+
+
 def test_metadata_get_data_with_empty_metadata_list():
     """
     metadata.get_data returns None when metadata input is an empty list.

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -934,6 +934,48 @@ def test_poll_once_returns_measurement_payload_when_data_is_available(monkeypatc
     assert bridge.state is runtime.BridgeState.READY
 
 
+def test_poll_once_skips_measurements_missing_from_metadata_when_enabled(caplog):
+    """
+    Metadata-only mode drops unmatched transmitters before any view or publish path.
+    """
+
+    class FakeSerial:
+        name = "/dev/cu.usbserial-test"
+
+        def write(self, _command):
+            return None
+
+        def read_until(self, _end):
+            return b"\x800 90 58 15006 145 11\x03"
+
+        def read(self, _size):
+            return runtime.scl.calc_bcc(b"\x800 90 58 15006 145 11\x03")
+
+    args = SimpleNamespace(
+        scl_address=126,
+        metadata_transmitters_only=True,
+    )
+    bridge = runtime.MtrBridge(
+        args,
+        transmitters_metadata=json.dumps([{"id": 99999, "location": "Elsewhere"}]),
+    )
+    bridge.receiver = runtime.ReceiverConnection(
+        serial_handle=FakeSerial(),
+        device_type="RTR970",
+        receiver_serial_number="RTR970123",
+        serial_config={"baudrate": 9600},
+    )
+
+    with caplog.at_level("DEBUG"):
+        result = bridge.poll_once()
+
+    assert result.state is runtime.BridgeState.READY
+    assert result.measurement_json is None
+    assert bridge.state is runtime.BridgeState.READY
+    assert caplog.records[-1].event == "measurement_skipped_unconfigured"
+    assert caplog.records[-1].measurement["id"] == "15006"
+
+
 def test_bridge_start_raises_receiver_error_when_no_receiver_is_found(monkeypatch):
     """
     Bridge startup reports missing receivers as a runtime exception.


### PR DESCRIPTION
## Summary
- add --metadata-transmitters-only and MTR2MQTT_METADATA_TRANSMITTERS_ONLY
- skip readings whose transmitter id is absent from metadata before MQTT, Home Assistant discovery, status, summary, and table output
- document metadata-only mode and add parser/runtime/metadata tests

## Validation
- uv run pytest
- make lint