### PR TITLE
fix(deps): update idna for CVE-2026-45409

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -299,11 +299,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.11"
+version = "3.16"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1a/88/bcf9709822fe69d02c2a6a77956c98ce6ea8ca8767a9aadcedc7eb6a2390/idna-3.16.tar.gz", hash = "sha256:d7a6da03db833450fca25d2358ac9ff06cd624577a4aea3a596d5c0f77b8e03d", size = 203770, upload-time = "2026-05-22T00:16:18.781Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
+    { url = "https://files.pythonhosted.org/packages/94/16/70255075a9859a0e3adb789b68ceb0e210dec03934245fd98d248226572f/idna-3.16-py3-none-any.whl", hash = "sha256:cc246e3a3f89580c3a951b5ad298ca4638078b2cdd4f115654332b5c26daded5", size = 74165, upload-time = "2026-05-22T00:16:16.698Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Updates the locked transitive `idna` dependency from 3.11 to 3.16 to address Dependabot alert 77 / GHSA-65pc-fj4g-8rjx / CVE-2026-45409. The advisory marks versions `< 3.15` as vulnerable, so the lockfile now resolves to a patched version.

## Validation

- `uv run python -c 'import idna; print(idna.__version__)'` -> `3.16`
- `uv run python -c 'import idna; payload="\\u0660"*10000; print(idna.__version__); import time; start=time.monotonic();\ntry:\n idna.encode(payload)\nexcept Exception as exc:\n print(type(exc).__name__, str(exc)[:120]); print(round(time.monotonic()-start, 3))'` -> `IDNAError Domain too long` in `0.0`s
- `make test` -> 128 passed
- `make lint` -> 10.00/10
- `make build` -> built sdist and wheel successfully

## Notes

No application code changes were needed; this is a lockfile-only dependency update.