### PR TITLE
fix(ci): fix Trivy image scan

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -52,6 +52,7 @@ jobs:
         continue-on-error: true
         with:
           image-ref: mtr2mqtt:trivy-${{ github.sha }}
+          vuln-type: os
           format: sarif
           output: trivy-image.sarif
           severity: HIGH,CRITICAL


### PR DESCRIPTION
## Summary
- limit the Trivy Docker image scan to OS packages with `vuln-type: os`
- keep Python dependency vulnerability scanning in the existing filesystem scan against `uv.lock`
- avoid false positives from the Python base image third-party SBOM for packages that are not installed in the runtime environment

## Validation
- `uv run python -c 'import yaml; yaml.safe_load(open(".github/workflows/trivy.yml", encoding="utf-8")); print("workflow yaml ok")'`
- `trivy fs --format table --severity HIGH,CRITICAL --ignore-unfixed --scanners vuln .`
- `make test`
- GitHub PR checks passed, including `Trivy scan`

## Notes
- The earlier Buildx and SARIF/reporting changes were removed; the PR now keeps the Docker build step unchanged.